### PR TITLE
Deploy templates to (un)delegate by calling the auction contract

### DIFF
--- a/Casper.Network.SDK/DeployTemplates.cs
+++ b/Casper.Network.SDK/DeployTemplates.cs
@@ -328,5 +328,112 @@ namespace Casper.Network.SDK
                 gasPrice,
                 ttl);
         }
+
+
+        private static Deploy CallAuctionContract(
+            HashKey contractHash,
+            string entryPoint,
+            PublicKey fromKey,
+            PublicKey validatorPK,
+            BigInteger amount,
+            BigInteger paymentAmount,
+            string chainName,
+            ulong gasPrice = 1,
+            ulong ttl = 1800000 //30m
+        )
+        {
+            var header = new DeployHeader()
+            {
+                Account = fromKey,
+                Timestamp = DateUtils.ToEpochTime(DateTime.UtcNow),
+                Ttl = ttl,
+                ChainName = chainName,
+                GasPrice = gasPrice
+            };
+            var payment = new ModuleBytesDeployItem(paymentAmount);
+
+            var runtimeArgs = new List<NamedArg>
+            {
+                new NamedArg("validator", CLValue.PublicKey(validatorPK)),
+                new NamedArg("amount", CLValue.U512(amount)),
+                new NamedArg("delegator", CLValue.PublicKey(fromKey))
+            };
+            var session = new StoredContractByHashDeployItem(contractHash.ToHexString(),
+                entryPoint, runtimeArgs);
+            
+            var deploy = new Deploy(header, payment, session);
+            return deploy;
+        }
+        
+        
+        /// <summary>
+        /// Creates a Deploy object to call the auction contract to delegate tokens to a validator for staking.
+        /// Make sure you use the correct contract hash for the network you're sending the deploy!
+        /// </summary>
+        /// <param name="contractHash">Hash of the delegation contract in the network.</param>
+        /// <param name="fromKey">Public key of the account that delegates the tokens.</param>
+        /// <param name="validatorPK">Public key of the validator to which the tokens are delegated for staking.</param>
+        /// <param name="amount">Amount of $CSPR (in motes) to delegate.</param>
+        /// <param name="paymentAmount">Amount of $CSPR (in motes) to pay for the delegation deployment.</param>
+        /// <param name="chainName">Name of the network that will execute the Deploy.</param>
+        /// <param name="gasPrice">Gas price. Use 1 unless you need a different value.</param>
+        /// <param name="ttl">Validity of the Deploy since the creation (in milliseconds).</param>
+        /// <returns>A deploy configured to delegate tokens to a validator for staking.</returns>
+        public static Deploy DelegateTokens(
+            HashKey contractHash,
+            PublicKey fromKey,
+            PublicKey validatorPK,
+            BigInteger amount,
+            BigInteger paymentAmount,
+            string chainName,
+            ulong gasPrice = 1,
+            ulong ttl = 1800000 //30m
+        )
+        {
+            return CallAuctionContract(contractHash,
+                "delegate",
+                fromKey,
+                validatorPK,
+                amount,
+                paymentAmount,
+                chainName,
+                gasPrice,
+                ttl);
+        }
+        
+        /// <summary>
+        /// Creates a Deploy object to call the auction contract to delegate tokens to a validator for staking.
+        /// Make sure you use the correct contract hash for the network you're sending the deploy!
+        /// </summary>
+        /// <param name="contractHash">Hash of the delegation contract in the network.</param>
+        /// <param name="fromKey">Public key of the account that delegates the tokens.</param>
+        /// <param name="validatorPK">Public key of the validator to which the tokens are delegated for staking.</param>
+        /// <param name="amount">Amount of $CSPR (in motes) to delegate.</param>
+        /// <param name="paymentAmount">Amount of $CSPR (in motes) to pay for the delegation deployment.</param>
+        /// <param name="chainName">Name of the network that will execute the Deploy.</param>
+        /// <param name="gasPrice">Gas price. Use 1 unless you need a different value.</param>
+        /// <param name="ttl">Validity of the Deploy since the creation (in milliseconds).</param>
+        /// <returns>A deploy configured to delegate tokens to a validator for staking.</returns>
+        public static Deploy UndelegateTokens(
+            HashKey contractHash,
+            PublicKey fromKey,
+            PublicKey validatorPK,
+            BigInteger amount,
+            BigInteger paymentAmount,
+            string chainName,
+            ulong gasPrice = 1,
+            ulong ttl = 1800000 //30m
+        )
+        {
+            return CallAuctionContract(contractHash,
+                "undelegate",
+                fromKey,
+                validatorPK,
+                amount,
+                paymentAmount,
+                chainName,
+                gasPrice,
+                ttl);
+        }
     }
 }

--- a/Docs/Examples/DelegateStake/DelegateStake.csproj
+++ b/Docs/Examples/DelegateStake/DelegateStake.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net5.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\Casper.Network.SDK\Casper.Network.SDK.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Docs/Examples/DelegateStake/Program.cs
+++ b/Docs/Examples/DelegateStake/Program.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Data;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Casper.Network.SDK;
+using Casper.Network.SDK.JsonRpc;
+using Casper.Network.SDK.Types;
+using Casper.Network.SDK.Utils;
+
+namespace CasperIntegrations
+{
+    public class DelegateStake
+    {
+        public static async Task Main(string[] args)
+        {
+            string nodeAddress = "http://testnet-node.make.services:7777/rpc";
+
+            try
+            {
+                // create an instance of the NetCasperClient that logs requests/outputs in stdout
+                //
+                var loggingHandler = new RpcLoggingHandler(new HttpClientHandler())
+                {
+                    LoggerStream = new StreamWriter(Console.OpenStandardOutput())
+                };
+                var casperSdk = new NetCasperClient(nodeAddress, loggingHandler);
+                
+                // load source account secret key from PEM files
+                //
+                var sourceKey = KeyPair.FromPem("./testnet1/secret_key.pem");
+
+                // choose a validator public key to stake the tokens
+                //
+                var validatorPK = PublicKey.FromHexString("017d96b9a63abcb61c870a4f55187a0a7ac24096bdb5fc585c12a686a4d892009e");
+                
+                // create a hash key with the auction contract hash
+                // IMPORTANT: this value changes between network. Double check you 
+                // are using the right contract hash before executing the deploy!
+                //
+                var contractHash = GlobalStateKey.FromString("hash-93d923e336b20a4c4ca14d592b60e5bd3fe330775618290104f9beb326db7ae2") as HashKey;
+
+                // prepare a transfer deploy using the DelegateTokens template.
+                // Similarly, use the template UndelegateTokens to undelegate.
+                //
+                var deploy = DeployTemplates.DelegateTokens(
+                    contractHash,
+                    sourceKey.PublicKey,
+                    validatorPK,
+                    100_000_000_000,
+                    3_000_000_000,
+                    "casper-test");
+
+                // sign the deploy and send it to the network
+                // use the source account secret key for signing.
+                //
+                deploy.Sign(sourceKey);
+
+                await casperSdk.PutDeploy(deploy);
+
+                var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+                var deployResponse = await casperSdk.GetDeploy(deploy.Hash, tokenSource.Token);
+
+                // only as an example, extract the transfer key, and retrieve the transfer
+                // information from the network
+                //
+                var result = deployResponse.Parse();
+                
+                if(result.ExecutionResults[0].IsSuccess)
+                    Console.WriteLine("Delegation successful");
+                else
+                    Console.WriteLine("Delegation completed with errors: " + result.ExecutionResults[0].ErrorMessage);
+            }
+            catch (RpcClientException e)
+            {
+                Console.WriteLine("ERROR:\n" + e.RpcError.Message);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Summary

Deploy templates to (un)delegate by calling the auction contract by its hash.

Previous templates require to use (un)delegate.wasm.
Added an example to show delegation in the Docs folder.

### TODO

Include integration test.

### Checklist

- [X] Code is properly formatted
- [X] All commits are signed
- [ ] Tests included/updated or not needed
- [X] Documentation (manuals or wiki) has been updated or is not required


