### PR TITLE
Bugfix. Call to Result is synchronous. Using await instead.

### DIFF
--- a/Casper.Network.SDK/NetCasperClient.cs
+++ b/Casper.Network.SDK/NetCasperClient.cs
@@ -267,7 +267,7 @@ namespace Casper.Network.SDK
             var response = await GetAccountInfo(publicKey);
             var purseUref = response.Result.GetProperty("account")
                 .GetProperty("main_purse").GetString();
-            return GetAccountBalance(purseUref, stateRootHash).Result;
+            return await GetAccountBalance(purseUref, stateRootHash);
         }
         
         /// <summary>


### PR DESCRIPTION

### Summary

A call to Task.Result blocks the execution while the `GetAccountBalance` should be asynchronous. Changed to `await`.

### Checklist

- [X] Code is properly formatted
- [X] All commits are signed
- [X] Tests included/updated or not needed
- [X] Documentation (manuals or wiki) has been updated or is not required

Signed-off-by: David Hernando <david.hernando@make.services>
