### PR TITLE
Remove dependency with Humanizer dll

### DIFF
--- a/Casper.Network.SDK.Test/DurationTest.cs
+++ b/Casper.Network.SDK.Test/DurationTest.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using Casper.Network.SDK.Utils;
+using NUnit.Framework;
+
+namespace NetCasperTest
+{
+    public class DurationTest
+    {
+        [Test]
+        public void MillisecondsToDurationTest()
+        {
+            Assert.AreEqual("31ms", DurationUtils.MillisecondsToString(31));
+            Assert.AreEqual("3s", DurationUtils.MillisecondsToString(3000));
+            Assert.AreEqual("30s", DurationUtils.MillisecondsToString(30_000));
+            Assert.AreEqual("1m", DurationUtils.MillisecondsToString(60_000));
+            Assert.AreEqual("10m", DurationUtils.MillisecondsToString(600_000));
+            Assert.AreEqual("30m", DurationUtils.MillisecondsToString(1_800_000));
+            Assert.AreEqual("2h", DurationUtils.MillisecondsToString(7_200_000));
+            Assert.AreEqual("1day", DurationUtils.MillisecondsToString(86_400_000));
+            Assert.AreEqual("2days", DurationUtils.MillisecondsToString(172_800_000));
+            Assert.AreEqual("7days", DurationUtils.MillisecondsToString(604_800_000));
+            Assert.AreEqual("1month", DurationUtils.MillisecondsToString(86_400_000d * 30.44d));
+            Assert.AreEqual("2months", DurationUtils.MillisecondsToString(172_800_000 * 30.44d));
+            Assert.AreEqual("1year", DurationUtils.MillisecondsToString(86_400_000d * 365.25d));
+            Assert.AreEqual("2years", DurationUtils.MillisecondsToString(172_800_000 * 365.25d));
+
+            Assert.AreEqual("2days 2h 30m 10s 31ms",
+                DurationUtils.MillisecondsToString(172_800_000
+                                                   + 7_200_000
+                                                   + 1_800_000
+                                                   + 10_000
+                                                   + 31));
+
+            Assert.AreEqual("2years 7months 10s 31ms",
+                DurationUtils.MillisecondsToString(172_800_000 * 365.25d
+                                                   + 7 * 86_400_000d * 30.44d
+                                                   + 10_000
+                                                   + 31));
+
+            Assert.AreEqual("0s", DurationUtils.MillisecondsToString(0));
+        }
+
+        [Test]
+        public void DurationToMillisecondsTest()
+        {
+            Assert.AreEqual(172_800_000
+                            + 7_200_000
+                            + 1_800_000
+                            + 10_000
+                            + 31,
+                DurationUtils.StringToMilliseconds("2days 2h 30m 10s 31ms"));
+
+            Assert.AreEqual(172_800_000 * 365.25d
+                            + 7 * 86_400_000d * 30.44d
+                            + 86_400_000
+                            + 10_000
+                            + 31,
+                DurationUtils.StringToMilliseconds("2years 7 months 1 day 10s 31ms"));
+
+            Assert.AreEqual(7 * 24 * 3600 * 1000,
+                DurationUtils.StringToMilliseconds("1week"));
+            Assert.AreEqual(7 * 24 * 3600 * 1000,
+                DurationUtils.StringToMilliseconds("1weeks"));
+            Assert.AreEqual(3 * 7 * 24 * 3600 * 1000,
+                DurationUtils.StringToMilliseconds("3weeks"));
+
+            Assert.AreEqual(0, DurationUtils.StringToMilliseconds("0years 0days 0s"));
+        }
+
+        [Test]
+        public void CatchWrongDurationTest()
+        {
+            var ex = Assert.Catch<ArgumentOutOfRangeException>(() =>
+                DurationUtils.MillisecondsToString(-1000d));
+            Assert.IsNotNull(ex);
+            Assert.IsTrue(ex.Message.Contains("Negative values not allowed."));
+
+            ex = Assert.Catch<ArgumentOutOfRangeException>(() =>
+                DurationUtils.MillisecondsToString(double.MaxValue));
+            Assert.IsNotNull(ex);
+
+            ex = Assert.Catch<ArgumentOutOfRangeException>(() =>
+                DurationUtils.StringToMilliseconds("584542047years"));
+            Assert.IsNotNull(ex);
+
+            ex = Assert.Catch<ArgumentOutOfRangeException>(() =>
+                DurationUtils.StringToMilliseconds("99999999999999999999999999ms"));
+            Assert.IsNotNull(ex);
+
+            ex = Assert.Catch<ArgumentOutOfRangeException>(() =>
+                DurationUtils.StringToMilliseconds("-1ms"));
+            Assert.IsNotNull(ex);
+
+            ex = Assert.Catch<ArgumentOutOfRangeException>(() =>
+                DurationUtils.StringToMilliseconds("ms"));
+            Assert.IsNotNull(ex);
+
+            ex = Assert.Catch<ArgumentOutOfRangeException>(() =>
+                DurationUtils.StringToMilliseconds("xms"));
+            Assert.IsNotNull(ex);
+
+            ex = Assert.Catch<ArgumentOutOfRangeException>(() =>
+                DurationUtils.StringToMilliseconds("7 eras"));
+            Assert.IsNotNull(ex);
+
+            ex = Assert.Catch<ArgumentOutOfRangeException>(() =>
+                DurationUtils.StringToMilliseconds("123"));
+            Assert.IsNotNull(ex);
+            
+            ex = Assert.Catch<ArgumentOutOfRangeException>(() =>
+                DurationUtils.StringToMilliseconds("1m 7"));
+            Assert.IsNotNull(ex);
+            
+            ex = Assert.Catch<ArgumentOutOfRangeException>(() =>
+                DurationUtils.StringToMilliseconds("1m 7 1ms"));
+            Assert.IsNotNull(ex);
+        }
+    }
+}

--- a/Casper.Network.SDK.Test/NctlContractTest.cs
+++ b/Casper.Network.SDK.Test/NctlContractTest.cs
@@ -31,7 +31,9 @@ namespace NetCasperTest
                 wasmBytes,
                 _faucetKey.PublicKey,
                 50_000_000_000,
-                _chainName);
+                _chainName,
+                1, //gasPrice=1
+                45011500); //ttl='12h 30m 11s 500ms'
             deploy.Sign(_faucetKey);
 
             var putResponse = await _client.PutDeploy(deploy);
@@ -87,7 +89,9 @@ namespace NetCasperTest
                 null,
                 _faucetKey.PublicKey,
                 15_000_000,
-                _chainName);
+                _chainName,
+                1, //gasPrice=1
+                24*3_600_000); //ttl='1day'
             deploy.Sign(_faucetKey);
 
             var putResponse = await _client.PutDeploy(deploy);

--- a/Casper.Network.SDK/Casper.Network.SDK.csproj
+++ b/Casper.Network.SDK/Casper.Network.SDK.csproj
@@ -21,7 +21,6 @@
 
     <ItemGroup>
       <PackageReference Include="BouncyCastle.NetCore" Version="1.8.8" />
-      <PackageReference Include="Humanizer" Version="2.11.10" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Casper.Network.SDK/Converters/HumanizeTTLConverter.cs
+++ b/Casper.Network.SDK/Converters/HumanizeTTLConverter.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Humanizer;
-using Humanizer.Localisation;
+using Casper.Network.SDK.Utils;
 
 namespace Casper.Network.SDK.Converters
 {
@@ -14,32 +12,10 @@ namespace Casper.Network.SDK.Converters
             Type typeToConvert,
             JsonSerializerOptions options)
         {
-            ulong ttl = 0;
-
             string humanizedTtl = reader.GetString();
             if (humanizedTtl is null) return 0;
-            
-            string[] parts = humanizedTtl.Split(new char[] {' '});
 
-            foreach (var xUnit in parts)
-            {
-                if (xUnit.Contains("ms"))
-                    ttl += ulong.Parse(xUnit.Replace("ms", ""));
-                else if(xUnit.Contains("s"))
-                    ttl += ulong.Parse(xUnit.Replace("s", ""))*1000;
-                else if(xUnit.Contains("m"))
-                    ttl += ulong.Parse(xUnit.Replace("m", ""))*60*1000;
-                else if(xUnit.Contains("h"))
-                    ttl += ulong.Parse(xUnit.Replace("h", ""))*3600*1000;
-                else if(xUnit.Contains("day"))
-                    ttl += ulong.Parse(xUnit.Replace("day", ""))*24*3600*1000;
-                else if(xUnit.Contains("d"))
-                    ttl += ulong.Parse(xUnit.Replace("d", ""))*24*3600*1000;
-                else
-                    throw new Exception($"Unsupported TTL part {xUnit}");
-            }
-
-            return ttl;
+            return DurationUtils.StringToMilliseconds(humanizedTtl);
         }
 
         public override void Write(
@@ -47,21 +23,7 @@ namespace Casper.Network.SDK.Converters
             ulong ttlInMillis,
             JsonSerializerOptions options)
         {
-            var ttlStr = TimeSpan.FromMilliseconds(ttlInMillis)
-                .Humanize(5, CultureInfo.InvariantCulture,
-                    TimeUnit.Day, TimeUnit.Millisecond, ",");
-            ttlStr = ttlStr.Replace("milliseconds", "ms")
-                .Replace("millisecond", "ms")
-                .Replace("seconds", "s")
-                .Replace("second", "s")
-                .Replace("minutes", "m")
-                .Replace("minute", "m")
-                .Replace("hours", "h")
-                .Replace("hour", "h")
-                .Replace("days", "d")
-                .Replace("day", "d")
-                .Replace(" ", "")
-                .Replace(",", " ");
+            var ttlStr = DurationUtils.MillisecondsToString(ttlInMillis);
 
             writer.WriteStringValue(ttlStr);
         }

--- a/Casper.Network.SDK/Utils/DurationUtils.cs
+++ b/Casper.Network.SDK/Utils/DurationUtils.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Text;
+
+namespace Casper.Network.SDK.Utils
+{
+    public class DurationUtils
+    {
+        private static void _item_tostr(StringBuilder str, string unit, double value, bool plural = false)
+        {
+            if (value > 0)
+            {
+                str.Append($"{value}{unit}");
+                if (plural && value > 1) str.Append("s");
+                str.Append(" ");
+            }
+        }
+
+        public static string MillisecondsToString(double milliseconds)
+        {
+            if (milliseconds < 0)
+                throw new ArgumentOutOfRangeException(nameof(milliseconds), "Negative values not allowed.");
+            ulong millis = (ulong)(milliseconds % 1000);
+
+            double secsd = (milliseconds - millis) / 1000;
+            if (secsd > ulong.MaxValue)
+                throw new ArgumentOutOfRangeException(nameof(milliseconds), $"The duration exceeds the maximum value of {ulong.MaxValue} seconds.");
+
+            ulong secs = (ulong)((milliseconds - millis) / 1000);
+
+            if (secs == 0 && millis == 0)
+                return "0s";
+
+            var years = secs / 31_557_600; // 365.25d
+            var ydays = secs % 31_557_600;
+            var months = ydays / 2_630_016; // 30.44d
+            var mdays = ydays % 2_630_016;
+            var days = mdays / 86400;
+            var day_secs = mdays % 86400;
+            var hours = day_secs / 3600;
+            var minutes = day_secs % 3600 / 60;
+            var seconds = day_secs % 60;
+
+            var str = new StringBuilder();
+
+            _item_tostr(str, "year", years, plural: true);
+            _item_tostr(str, "month", months, plural: true);
+            _item_tostr(str, "day", days, plural: true);
+            _item_tostr(str, "h", hours);
+            _item_tostr(str, "m", minutes);
+            _item_tostr(str, "s", seconds);
+            _item_tostr(str, "ms", millis);
+
+            return str.ToString().TrimEnd();
+        }
+
+        private static ulong _parse_item(string value, string unit, double mul)
+        {
+            value = value.Replace(unit, "");
+            if (string.IsNullOrWhiteSpace(value) ||
+                !ulong.TryParse(value, out var number))
+                throw new ArgumentOutOfRangeException(nameof(value), "Cannot convert duration '{value}'");
+
+            if (number * mul > ulong.MaxValue)
+                throw new ArgumentOutOfRangeException(nameof(value),
+                    $"The duration exceeds the maximum value of {ulong.MaxValue} milliseconds.");
+            
+            return (ulong) (number * mul);
+        }
+        
+        public static ulong StringToMilliseconds(string duration)
+        {
+            ulong millis = 0;
+            
+            string[] parts = duration.Split(new char[] {' '});
+
+            string remainder = string.Empty;
+            
+            for (int i = 0; i < parts.Length;)
+            {
+                var xUnit = remainder + parts[i];
+
+                if (xUnit.Contains("years"))
+                    millis += _parse_item(xUnit, "years", 365.25d * 24 * 3600 * 1000);
+                else if (xUnit.Contains("year"))
+                    millis += _parse_item(xUnit, "year", 365.25d * 24 * 3600 * 1000);
+                else if (xUnit.Contains("months"))
+                    millis += _parse_item(xUnit, "months", 30.44d * 24 * 3600 * 1000);
+                else if (xUnit.Contains("month"))
+                    millis += _parse_item(xUnit, "month", 30.44d * 24 * 3600 * 1000);
+                else if (xUnit.Contains("weeks"))
+                    millis += _parse_item(xUnit, "weeks", 7d * 24 * 3600 * 1000);
+                else if (xUnit.Contains("week"))
+                    millis += _parse_item(xUnit, "week", 7d * 24 * 3600 * 1000);
+                else if (xUnit.Contains("days"))
+                    millis += _parse_item(xUnit, "days", 24 * 3600 * 1000);
+                else if (xUnit.Contains("day"))
+                    millis += _parse_item(xUnit, "day", 24 * 3600 * 1000);
+                else if (xUnit.Contains("ms"))
+                    millis += _parse_item(xUnit, "ms", 1);
+                else if (xUnit.Contains("s"))
+                    millis += _parse_item(xUnit, "s", 1000);
+                else if (xUnit.Contains("m"))
+                    millis += _parse_item(xUnit, "m", 60 * 1000);
+                else if (xUnit.Contains("h"))
+                    millis += _parse_item(xUnit, "h", 3600 * 1000);
+                else if (ulong.TryParse(xUnit, out var _) &&
+                         string.IsNullOrEmpty(remainder) &&
+                         i < parts.Length - 1 && 
+                         !char.IsDigit(parts[i + 1].ToCharArray()[0]))
+                {
+                    remainder = xUnit;
+                    i++;
+                    continue;
+                }
+                else
+                    throw new ArgumentOutOfRangeException(nameof(duration), $"Unsupported Duration part {xUnit}");
+
+                remainder = "";
+                i++;
+            }
+
+            return millis;
+        }
+    }
+}


### PR DESCRIPTION
### Summary

Humanizer was used to convert TTL from milliseconds to strings.
For the web library it is convenient to remove this dependency to reduce the size of the downloaded components.

### TODO

n/a

### Checklist

- [X] Code is properly formatted
- [X] All commits are signed
- [X] Tests included/updated or not needed
- [X] Documentation (manuals or wiki) has been updated or is not required


