### PR TITLE
Replace Thread.Sleep() with Task.Delay().

### DIFF
--- a/Casper.Network.SDK/NetCasperClient.cs
+++ b/Casper.Network.SDK/NetCasperClient.cs
@@ -305,7 +305,7 @@ namespace Casper.Network.SDK
                 if (!cancellationToken.CanBeCanceled ||
                     response.Result.GetProperty("execution_results").GetArrayLength() > 0)
                     return response;
-                Thread.Sleep(10000);
+                await Task.Delay(10000);
             }
 
             throw new TaskCanceledException("GetDeploy operation canceled");

--- a/Casper.Network.SDK/SSE/ServerEventsClient.cs
+++ b/Casper.Network.SDK/SSE/ServerEventsClient.cs
@@ -209,7 +209,7 @@ namespace Casper.Network.SDK.SSE
                     var tokenSource = new CancellationTokenSource();
                     var task = ListenChannelAsync(channelType.Key, channelType.Value, tokenSource.Token);
                     _runningTasks.Add(channelType.Key, new Tuple<Task, CancellationTokenSource>(task, tokenSource));
-                    Thread.Sleep(3000);
+                    Task.Delay(3000).Wait();
                 }
             }
         }
@@ -285,7 +285,7 @@ namespace Casper.Network.SDK.SSE
                     {
                         Console.WriteLine($"Error: {ex.Message}");
                         Console.WriteLine("Retrying in 5 seconds");
-                        Thread.Sleep(5000);
+                        await Task.Delay(5000, cancelToken);
                     }
                 }
             }, cancelToken);


### PR DESCRIPTION
### Summary

Sleep() blocks current thread and, specifically, In ASP.Net apps, it makes the application unresponsive.

### TODO

n/a

### Checklist

- [x] Code is properly formatted
- [x] All commits are signed
- [x] Tests included/updated or not needed
- [x] Documentation (manuals or wiki) has been updated or is not required
