### PR TITLE
Interfaces for RPC and SSE client classes

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -16,6 +16,8 @@ jobs:
         # Docker Hub image
         image: makesoftware/casper-nctl:latest
         options: --name casper-nctl
+        env:
+          DEPLOY_DELAY: '5sec'          
         ports:
           # Opens RPC, REST and events ports on the host and service container
           - 11101:11101

--- a/Casper.Network.SDK.Test/NctlTransferTest.cs
+++ b/Casper.Network.SDK.Test/NctlTransferTest.cs
@@ -146,7 +146,7 @@ namespace NetCasperTest
                 wasmBytes,
                 _myAccount.PublicKey,
                 validatorPk,
-                100_000_000_000,
+                600_000_000_000,
                 5_000_000_000,
                 _chainName);
             deploy.Sign(_myAccount);

--- a/Casper.Network.SDK/ICasperClient.cs
+++ b/Casper.Network.SDK/ICasperClient.cs
@@ -1,0 +1,84 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Casper.Network.SDK.JsonRpc;
+using Casper.Network.SDK.JsonRpc.ResultTypes;
+using Casper.Network.SDK.Types;
+
+namespace Casper.Network.SDK
+{
+    public interface ICasperClient
+    {
+        Task<string> GetStateRootHash(string blockHash = null);
+
+        Task<string> GetStateRootHash(int blockHeight);
+
+        Task<RpcResponse<GetNodeStatusResult>> GetNodeStatus();
+
+        Task<RpcResponse<GetNodePeersResult>> GetNodePeers();
+
+        Task<RpcResponse<GetAuctionInfoResult>> GetAuctionInfo(string blockHash = null);
+
+        Task<RpcResponse<GetAuctionInfoResult>> GetAuctionInfo(int blockHeight);
+
+        Task<RpcResponse<GetAccountInfoResult>> GetAccountInfo(PublicKey publicKey, string blockHash = null);
+
+        Task<RpcResponse<GetAccountInfoResult>> GetAccountInfo(string publicKey, string blockHash = null);
+
+        Task<RpcResponse<GetAccountInfoResult>> GetAccountInfo(PublicKey publicKey, int blockHeight);
+
+        Task<RpcResponse<GetAccountInfoResult>> GetAccountInfo(string publicKey, int blockHeight);
+
+        Task<RpcResponse<QueryGlobalStateResult>> QueryGlobalState(string key, string stateRootHash = null,
+            string path = null);
+        
+        Task<RpcResponse<QueryGlobalStateResult>> QueryGlobalState(GlobalStateKey key, string stateRootHash = null,
+            string path = null);
+
+        Task<RpcResponse<QueryGlobalStateResult>> QueryGlobalStateWithBlockHash(string key, string blockHash,
+            string path = null);
+
+        Task<RpcResponse<QueryGlobalStateResult>> QueryGlobalStateWithBlockHash(GlobalStateKey key, string blockHash, 
+            string path = null);
+
+        Task<RpcResponse<GetBalanceResult>> GetAccountBalance(string purseURef,
+            string stateRootHash = null);
+
+        Task<RpcResponse<GetBalanceResult>> GetAccountBalance(URef purseURef,
+            string stateRootHash = null);
+
+        Task<RpcResponse<GetBalanceResult>> GetAccountBalance(PublicKey publicKey,
+            string stateRootHash = null);
+
+        Task<RpcResponse<PutDeployResult>> PutDeploy(Deploy deploy);
+
+        Task<RpcResponse<GetDeployResult>> GetDeploy(string deployHash,
+            CancellationToken cancellationToken = default(CancellationToken));
+        
+        Task<RpcResponse<GetBlockResult>> GetBlock(string blockHash = null);
+
+        Task<RpcResponse<GetBlockResult>> GetBlock(int blockHeight);
+
+        Task<RpcResponse<GetBlockTransfersResult>> GetBlockTransfers(string blockHash = null);
+        
+        Task<RpcResponse<GetBlockTransfersResult>> GetBlockTransfers(int blockHeight);
+
+        Task<RpcResponse<GetEraInfoBySwitchBlockResult>> GetEraInfoBySwitchBlock(string blockHash = null);
+
+        Task<RpcResponse<GetEraInfoBySwitchBlockResult>> GetEraInfoBySwitchBlock(int blockHeight);
+
+        Task<RpcResponse<GetDictionaryItemResult>> GetDictionaryItem(string dictionaryItem, string stateRootHash = null);
+
+        Task<RpcResponse<GetDictionaryItemResult>> GetDictionaryItemByAccount(string accountKey, string dictionaryName,
+            string dictionaryItem, string stateRootHash = null);
+        
+        Task<RpcResponse<GetDictionaryItemResult>> GetDictionaryItemByContract(string contractKey, string dictionaryName, 
+            string dictionaryItem, string stateRootHash = null);
+
+        Task<RpcResponse<GetDictionaryItemResult>> GetDictionaryItemByURef(string seedURef,
+            string dictionaryItem, string stateRootHash = null);
+
+        Task<RpcResponse<GetValidatorChangesResult>> GetValidatorChanges();
+
+        Task<string> GetRpcSchema();
+    }
+}

--- a/Casper.Network.SDK/NetCasperClient.cs
+++ b/Casper.Network.SDK/NetCasperClient.cs
@@ -14,7 +14,7 @@ namespace Casper.Network.SDK
     /// <summary>
     /// Client to communicate with a Casper node.
     /// </summary>
-    public class NetCasperClient : IDisposable
+    public class NetCasperClient : ICasperClient, IDisposable
     {
         private volatile bool _disposed;
 

--- a/Casper.Network.SDK/SSE/ISSEClient.cs
+++ b/Casper.Network.SDK/SSE/ISSEClient.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+
+namespace Casper.Network.SDK.SSE
+{
+    public interface ISSEClient
+    {
+        void AddEventCallback(EventType eventType, string name, EventCallback cb, 
+                                int startFrom = int.MaxValue);
+
+        bool RemoveEventCallback(EventType eventType, string name);
+
+        void StartListening();
+
+        Task StopListening();
+
+        void Wait();
+    }
+}


### PR DESCRIPTION
### Summary

- To use dependency injection in ASP.NET Core it's necessary that the RPC and SSE client classes implement an interface.
- Fix for integration tests: Delegate test needs a minimum quantity of 500 CSPR.

### TODO

n/a

### Checklist

- [x] Code is properly formatted
- [x] All commits are signed
- [x] Tests included/updated or not needed
- [x] Documentation (manuals or wiki) has been updated or is not required


