### PR TITLE
Added optional `finalized_approvals` parameter to `GetDeploy` method.

### DIFF
--- a/Casper.Network.SDK.Test/CasperMethodsTest.cs
+++ b/Casper.Network.SDK.Test/CasperMethodsTest.cs
@@ -1,0 +1,26 @@
+﻿using Casper.Network.SDK.JsonRpc;
+using NUnit.Framework;
+
+namespace NetCasperTest
+{
+    public class CasperMethodsTest
+    {
+        private string dummyDeployHash = "000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f";
+        
+        [Test]
+        public void GetDeployMethodTest()
+        {
+            var method = new GetDeploy(dummyDeployHash);
+            var jsonStr = method.Serialize();
+            Assert.IsFalse(jsonStr.Contains("finalized_approvals"));
+
+            method = new GetDeploy(dummyDeployHash, false);
+            jsonStr = method.Serialize();
+            Assert.IsFalse(jsonStr.Contains("finalized_approvals"));
+
+            method = new GetDeploy(dummyDeployHash, true);
+            jsonStr = method.Serialize();
+            Assert.IsTrue(jsonStr.Contains(@"""finalized_approvals"": true"));
+        }
+    }
+}

--- a/Casper.Network.SDK/JsonRpc/CasperMethods.cs
+++ b/Casper.Network.SDK/JsonRpc/CasperMethods.cs
@@ -223,12 +223,18 @@ namespace Casper.Network.SDK.JsonRpc
         /// Retrieves a Deploy from the network.
         /// </summary>
         /// <param name="deployHash">Hash of the deploy to retrieve.</param>
-        public GetDeploy(string deployHash) : base("info_get_deploy")
+        /// <param name="finalizedApprovals">Whether to return the deploy with the finalized approvals
+        /// substituted. If `false` or omitted, returns the deploy with the approvals that were originally
+        /// received by the node.</param>
+        public GetDeploy(string deployHash, bool finalizedApprovals = false) : base("info_get_deploy")
         {
             this.Parameters = new Dictionary<string, object>
             {
                 {"deploy_hash", deployHash}
             };
+            
+            if(finalizedApprovals)
+                this.Parameters.Add("finalized_approvals", true);
         }
     }
 

--- a/Casper.Network.SDK/NetCasperClient.cs
+++ b/Casper.Network.SDK/NetCasperClient.cs
@@ -297,7 +297,26 @@ namespace Casper.Network.SDK
         public async Task<RpcResponse<GetDeployResult>> GetDeploy(string deployHash,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            var method = new GetDeploy(deployHash);
+            return await GetDeploy(deployHash, false, cancellationToken);
+        }
+
+        /// <summary>
+        /// Request a Deploy object from the network by the deploy hash.
+        /// When a cancellation token is included this method waits until the deploy is
+        /// executed, i.e. until the deploy contains the execution results information.
+        /// </summary>
+        /// <param name="deployHash">Hash of the deploy to retrieve.</param>
+        /// <param name="finalizedApprovals">Whether to return the deploy with the finalized approvals
+        /// substituted. If `false` or omitted, returns the deploy with the approvals that were originally
+        /// received by the node.</param>
+        /// <param name="cancellationToken">A CancellationToken. Do not include this parameter to return
+        /// with the first deploy object returned by the network, even it's not executed.</param>
+        /// <exception cref="TaskCanceledException">The token has cancelled the operation before the deploy has been executed.</exception>
+        public async Task<RpcResponse<GetDeployResult>> GetDeploy(string deployHash,
+            bool finalizedApprovals,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var method = new GetDeploy(deployHash, finalizedApprovals);
 
             while (!cancellationToken.IsCancellationRequested)
             {


### PR DESCRIPTION
### Summary

Casper Node v1.4.5 adds an optional `finalized_approvals` parameter to `GetDeploy` method.

### TODO

n/a

### Checklist

- [x] Code is properly formatted
- [x] All commits are signed
- [x] Tests included/updated or not needed
- [x] Documentation (manuals or wiki) has been updated or is not required

