### PR TITLE
[Feature] Compatibility with Unity - netstandard2.0 target

### DIFF
--- a/.github/workflows/unity-compat.yml
+++ b/.github/workflows/unity-compat.yml
@@ -1,0 +1,24 @@
+name: Unity Compat - Build and Test
+
+on:
+  push:
+    branches: [feature/unity-compat]
+  pull_request:
+    branches: [feature/unity-compat]
+
+jobs:
+  buildntest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 7.0.x
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore
+      - name: Test
+        run: dotnet test --no-build --verbosity normal --filter "TestCategory!~NCTL"

--- a/.github/workflows/unity-compat.yml
+++ b/.github/workflows/unity-compat.yml
@@ -2,9 +2,9 @@ name: Unity Compat - Build and Test
 
 on:
   push:
-    branches: [feature/unity-compat]
+    branches: [netstandard-2-0-target]
   pull_request:
-    branches: [feature/unity-compat]
+    branches: [netstandard-2-0-target]
 
 jobs:
   buildntest:

--- a/Casper.Network.SDK/Casper.Network.SDK.csproj
+++ b/Casper.Network.SDK/Casper.Network.SDK.csproj
@@ -22,6 +22,7 @@
 
     <ItemGroup>
       <PackageReference Include="BouncyCastle.NetCore" Version="1.9.0" />
+      <PackageReference Include="System.Text.Json" Version="7.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Casper.Network.SDK/Casper.Network.SDK.csproj
+++ b/Casper.Network.SDK/Casper.Network.SDK.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>9.0</LangVersion>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
         <FileVersion>2.0.0</FileVersion>
         <PackageVersion>2.0.0</PackageVersion>

--- a/Casper.Network.SDK/Casper.Network.SDK.csproj
+++ b/Casper.Network.SDK/Casper.Network.SDK.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
         <FileVersion>2.0.0</FileVersion>
         <PackageVersion>2.0.0</PackageVersion>

--- a/Casper.Network.SDK/Casper.Network.SDK.csproj
+++ b/Casper.Network.SDK/Casper.Network.SDK.csproj
@@ -22,6 +22,7 @@
 
     <ItemGroup>
       <PackageReference Include="BouncyCastle.NetCore" Version="1.9.0" />
+      <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
       <PackageReference Include="System.Text.Json" Version="7.0.3" />
     </ItemGroup>
 

--- a/Casper.Network.SDK/Compat/BigIntegerCompat.cs
+++ b/Casper.Network.SDK/Compat/BigIntegerCompat.cs
@@ -1,0 +1,34 @@
+#if NETSTANDARD2_0
+
+using System;
+using System.Numerics;
+
+public class BigIntegerCompat
+{
+    public static BigInteger Create(byte[] value, bool isUnsigned = false, bool isBigEndian = false)
+    {
+        if (value == null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        if (isBigEndian)
+        {
+            Array.Reverse(value);
+        }
+
+        if (isUnsigned)
+        {
+            // Ensure that the resulting BigInteger is treated as an unsigned value by appending a 0 byte if necessary
+            if (value[value.Length - 1] >= 0x80)
+            {
+                Array.Resize(ref value, value.Length + 1);
+                value[value.Length - 1] = 0;
+            }
+        }
+
+        return new BigInteger(value);
+    }
+}
+
+#endif

--- a/Casper.Network.SDK/Compat/BigIntegerExtensions.cs
+++ b/Casper.Network.SDK/Compat/BigIntegerExtensions.cs
@@ -1,0 +1,32 @@
+#if NETSTANDARD2_0
+
+using System;
+using System.Numerics;
+
+public static class BigIntegerExtensions
+{
+    public static byte[] ToByteArray(this BigInteger value, bool isUnsigned = false)
+    {
+        byte[] bytes = value.ToByteArray();
+
+        if (isUnsigned)
+        {
+            if (value < 0)
+            {
+                throw new InvalidOperationException("Cannot retrieve an unsigned byte array representation of a negative BigInteger.");
+            }
+
+            // If the BigInteger is positive and the highest byte is 0x80 or higher,
+            // an additional byte is added to indicate a positive number when using two's complement notation.
+            // For the unsigned representation, this additional byte is not necessary.
+            if (bytes.Length > 1 && bytes[bytes.Length - 1] == 0)
+            {
+                Array.Resize(ref bytes, bytes.Length - 1);
+            }
+        }
+
+        return bytes;
+    }
+}
+
+#endif

--- a/Casper.Network.SDK/Compat/BitConverterExtensions.cs
+++ b/Casper.Network.SDK/Compat/BitConverterExtensions.cs
@@ -1,0 +1,28 @@
+#if NETSTANDARD2_0
+
+using System;
+
+public static class BitConverterExtensions
+{
+    public static Int64 ToInt64(byte[] value, int startIndex = 0)
+    {
+        return BitConverter.ToInt64(value, startIndex);
+    }
+
+    public static Int32 ToInt32(byte[] value, int startIndex = 0)
+    {
+        return BitConverter.ToInt32(value, startIndex);
+    }
+
+    public static UInt64 ToUInt64(byte[] value, int startIndex = 0)
+    {
+        return BitConverter.ToUInt64(value, startIndex);
+    }
+
+    public static UInt32 ToUInt32(byte[] value, int startIndex = 0)
+    {
+        return BitConverter.ToUInt32(value, startIndex);
+    }
+}
+
+#endif

--- a/Casper.Network.SDK/Compat/BytesExtensions.cs
+++ b/Casper.Network.SDK/Compat/BytesExtensions.cs
@@ -1,0 +1,25 @@
+#if NETSTANDARD2_0
+
+using System;
+
+public static class BytesExtensions
+{
+    public static byte[] Slice(this byte[] bytes, int from, int? to = null)
+    {
+        int actualTo = to ?? bytes.Length;  // if to is not provided, use the last index
+
+        if (from < 0 || actualTo > bytes.Length || from > actualTo)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        int length = actualTo - from;
+        byte[] result = new byte[length];
+
+        Array.Copy(bytes, from, result, 0, length);
+
+        return result;
+    }
+}
+
+#endif

--- a/Casper.Network.SDK/Compat/DateTimeCompat.cs
+++ b/Casper.Network.SDK/Compat/DateTimeCompat.cs
@@ -1,0 +1,11 @@
+#if NETSTANDARD2_0
+
+using System;
+using System.Globalization;
+
+public static class DateTimeCompat
+{
+    public static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+}
+
+#endif

--- a/Casper.Network.SDK/Compat/EnumCompat.cs
+++ b/Casper.Network.SDK/Compat/EnumCompat.cs
@@ -1,12 +1,18 @@
 #if NETSTANDARD2_0
 
 using System;
+using System.Linq;
 
 public static class EnumCompat
 {
     public static TEnum Parse<TEnum>(this String value) where TEnum : struct
     {
         return (TEnum)Enum.Parse(typeof(TEnum), value);
+    }
+
+    public static string GetName<TEnum>(TEnum value) where TEnum : Enum
+    {
+        return Enum.GetName(typeof(TEnum), value);
     }
 }
 

--- a/Casper.Network.SDK/Compat/EnumCompat.cs
+++ b/Casper.Network.SDK/Compat/EnumCompat.cs
@@ -1,0 +1,13 @@
+#if NETSTANDARD2_0
+
+using System;
+
+public static class EnumCompat
+{
+    public static TEnum Parse<TEnum>(this String value) where TEnum : struct
+    {
+        return (TEnum)Enum.Parse(typeof(TEnum), value);
+    }
+}
+
+#endif

--- a/Casper.Network.SDK/Compat/HttpClientExtensions.cs
+++ b/Casper.Network.SDK/Compat/HttpClientExtensions.cs
@@ -1,0 +1,22 @@
+#if NETSTANDARD2_0
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+public static class HttpClientExtensions
+{
+    public static async Task<Stream> GetStreamAsync(this HttpClient client, Uri uri, CancellationToken cancelToken)
+    {
+        var response = await client.GetAsync(uri, cancelToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new HttpRequestException($"Request to {uri} returned with HTTP status code {response.StatusCode}");
+        }
+        return await response.Content.ReadAsStreamAsync();
+    }
+}
+
+#endif

--- a/Casper.Network.SDK/Compat/IsExternalInit.cs
+++ b/Casper.Network.SDK/Compat/IsExternalInit.cs
@@ -1,0 +1,18 @@
+#if NETSTANDARD2_0
+
+using System.ComponentModel;
+
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit
+    {
+    }
+}
+
+#endif

--- a/Casper.Network.SDK/Compat/MemoryStreamExtensions.cs
+++ b/Casper.Network.SDK/Compat/MemoryStreamExtensions.cs
@@ -1,0 +1,13 @@
+#if NETSTANDARD2_0
+
+using System.IO;
+
+public static class MemoryStreamExtensions
+{
+    public static void Write(this MemoryStream stream, byte[] buffer)
+    {
+        stream.Write(buffer, 0, buffer.Length);
+    }
+}
+
+#endif

--- a/Casper.Network.SDK/Compat/Tuple.cs
+++ b/Casper.Network.SDK/Compat/Tuple.cs
@@ -1,0 +1,92 @@
+#if NETSTANDARD2_0
+
+using System;
+
+public partial interface ITuple
+{
+    object this[int index] { get; }
+    int Length { get; }
+}
+
+public class Tuple<T1> : ITuple
+{
+    public T1 Item1 { get; }
+
+    public Tuple(T1 item1)
+    {
+        Item1 = item1;
+    }
+
+    public int Length => 1;
+
+    public object this[int index]
+    {
+        get
+        {
+            switch (index)
+            {
+                case 0: return Item1;
+                default: throw new IndexOutOfRangeException();
+            }
+        }
+    }
+}
+
+public class Tuple<T1, T2> : ITuple
+{
+    public T1 Item1 { get; }
+    public T2 Item2 { get; }
+
+    public Tuple(T1 item1, T2 item2)
+    {
+        Item1 = item1;
+        Item2 = item2;
+    }
+
+    public int Length => 2;
+
+    public object this[int index]
+    {
+        get
+        {
+            switch (index)
+            {
+                case 0: return Item1;
+                case 1: return Item2;
+                default: throw new IndexOutOfRangeException();
+            }
+        }
+    }
+}
+
+public class Tuple<T1, T2, T3> : ITuple
+{
+    public T1 Item1 { get; }
+    public T2 Item2 { get; }
+    public T3 Item3 { get; }
+
+    public Tuple(T1 item1, T2 item2, T3 item3)
+    {
+        Item1 = item1;
+        Item2 = item2;
+        Item3 = item3;
+    }
+
+    public int Length => 3;
+
+    public object this[int index]
+    {
+        get
+        {
+            switch (index)
+            {
+                case 0: return Item1;
+                case 1: return Item2;
+                case 2: return Item3;
+                default: throw new IndexOutOfRangeException();
+            }
+        }
+    }
+}
+
+#endif

--- a/Casper.Network.SDK/JsonRpc/RpcClient.cs
+++ b/Casper.Network.SDK/JsonRpc/RpcClient.cs
@@ -65,8 +65,8 @@ namespace Casper.Network.SDK.JsonRpc
                 strMethod,
                 System.Text.Encoding.UTF8,
                 "application/json"); //CONTENT-TYPE header
-            if(request.Content.Headers.ContentType != null)
-                request.Content.Headers.ContentType.CharSet = "";
+            request.Content.Headers.Remove("Content-Type"); // "{application/json; charset=utf-8}"
+            request.Content.Headers.Add("Content-Type", "application/json");
 
             try
             {

--- a/Casper.Network.SDK/Types/CLValue.cs
+++ b/Casper.Network.SDK/Types/CLValue.cs
@@ -536,7 +536,7 @@ namespace Casper.Network.SDK.Types
 
         private void ParseResultError(byte[] Bytes, CLResultTypeInfo resultTypeInfo)
         {
-            var reader = new BinaryReader(new MemoryStream(Bytes[1..]));
+            var reader = new BinaryReader(new MemoryStream(Bytes.Slice(1)));
 
             var item = reader.ReadCLItem(resultTypeInfo.Err, null);
             if (item == null)
@@ -554,7 +554,7 @@ namespace Casper.Network.SDK.Types
                 ParseResultError(Bytes, resultTypeInfo);
 
             typeInfo = resultTypeInfo.Ok;
-            return Bytes[1..];
+            return Bytes.Slice(1);
         }
 
         /// <summary>
@@ -786,8 +786,9 @@ namespace Casper.Network.SDK.Types
             if (typeInfo.Type == CLType.URef)
                 return new URef(bytes);
 
-            if (typeInfo.Type == CLType.Key && ((CLKeyTypeInfo) typeInfo).KeyIdentifier == KeyIdentifier.URef)
-                return new URef(bytes[1..]);
+            if (typeInfo.Type == CLType.Key && ((CLKeyTypeInfo) typeInfo).KeyIdentifier == KeyIdentifier.URef) {
+                return new URef(bytes.Slice(1));
+            }
 
             throw new FormatException($"Cannot convert '{typeInfo.Type}' to 'URef'.");
         }
@@ -1029,13 +1030,13 @@ namespace Casper.Network.SDK.Types
 
             if (Bytes[0] == 0x01)
             {
-                var reader = new BinaryReader(new MemoryStream(Bytes[1..]));
+                var reader = new BinaryReader(new MemoryStream(Bytes.Slice(1)));
                 var v = reader.ReadCLItem(resultTypeInfo.Ok, typeof(TOk));
                 return Result<TOk, TErr>.Ok((TOk) v);
             }
             else
             {
-                var reader = new BinaryReader(new MemoryStream(Bytes[1..]));
+                var reader = new BinaryReader(new MemoryStream(Bytes.Slice(1)));
                 var v = reader.ReadCLItem(resultTypeInfo.Err, typeof(TErr));
                 return Result<TOk, TErr>.Fail((TErr)v);
             }
@@ -1076,7 +1077,7 @@ namespace Casper.Network.SDK.Types
                 if(typeInfo==null)
                     throw new ArgumentException(nameof(value), $"value is not an 'Option' CLValue.");
 
-                var reader = new BinaryReader(new MemoryStream(Bytes[1..]));
+                var reader = new BinaryReader(new MemoryStream(Bytes.Slice(1)));
                 value = reader.ReadCLItem(typeInfo.OptionType, null);
             }
 
@@ -1098,7 +1099,7 @@ namespace Casper.Network.SDK.Types
                 if(typeInfo==null)
                     throw new ArgumentException(nameof(value), $"value is not an 'Option' CLValue.");
 
-                var reader = new BinaryReader(new MemoryStream(Bytes[1..]));
+                var reader = new BinaryReader(new MemoryStream(Bytes.Slice(1)));
                 value = (T) reader.ReadCLItem(typeInfo.OptionType, typeof(T));
                 
                 return true;

--- a/Casper.Network.SDK/Types/CLValueException.cs
+++ b/Casper.Network.SDK/Types/CLValueException.cs
@@ -20,7 +20,7 @@ namespace Casper.Network.SDK.Types
         }
 
         public CLValueException(byte[] bytes, CLTypeInfo okType, CLTypeInfo errType) 
-            : base($"Cannot convert {Hex.ToHexString(bytes[1..])}' to '{errType}'.")
+            : base($"Cannot convert {Hex.ToHexString(bytes.Slice(1))}' to '{errType}'.")
         {
             Bytes = bytes;
             ErrorValue = null;

--- a/Casper.Network.SDK/Types/GlobalStateKey.cs
+++ b/Casper.Network.SDK/Types/GlobalStateKey.cs
@@ -171,21 +171,21 @@ namespace Casper.Network.SDK.Types
         {
             return bytes[0] switch
             {
-                0x00 => new AccountHashKey("account-hash-" + CEP57Checksum.Encode(bytes[1..])),
-                0x01 => new HashKey("hash-" + CEP57Checksum.Encode(bytes[1..])),
-                0x02 => new URef(bytes[1..]),
-                0x03 => new TransferKey("transfer-" + CEP57Checksum.Encode(bytes[1..])),
-                0x04 => new DeployInfoKey("deploy-" + CEP57Checksum.Encode(bytes[1..])),
+                0x00 => new AccountHashKey("account-hash-" + CEP57Checksum.Encode(bytes.Slice(1))),
+                0x01 => new HashKey("hash-" + CEP57Checksum.Encode(bytes.Slice(1))),
+                0x02 => new URef(bytes.Slice(1)),
+                0x03 => new TransferKey("transfer-" + CEP57Checksum.Encode(bytes.Slice(1))),
+                0x04 => new DeployInfoKey("deploy-" + CEP57Checksum.Encode(bytes.Slice(1))),
                 0x05 => new EraInfoKey("era-" + BitConverter.ToInt64(bytes, 1)),
-                0x06 => new BalanceKey("balance-" + CEP57Checksum.Encode(bytes[1..])),
-                0x07 => new BidKey("bid-" + CEP57Checksum.Encode(bytes[1..])),
-                0x08 => new WithdrawKey("withdraw-" + CEP57Checksum.Encode(bytes[1..])),
-                0x09 => new DictionaryKey("dictionary-" + CEP57Checksum.Encode(bytes[1..])),
-                0x0a => new SystemContractRegistryKey("system-contract-registry-" + CEP57Checksum.Encode(bytes[1..])),
-                0x0b => new EraSummaryKey("era-summary-" + CEP57Checksum.Encode(bytes[1..])),
-                0x0c => new UnbondKey("unbond-" + CEP57Checksum.Encode(bytes[1..])),
-                0x0d => new ChainspecRegistryKey("chainspec-registry-" + CEP57Checksum.Encode(bytes[1..])),
-                0x0e => new ChecksumRegistryKey("checksum-registry-" + CEP57Checksum.Encode(bytes[1..])),
+                0x06 => new BalanceKey("balance-" + CEP57Checksum.Encode(bytes.Slice(1))),
+                0x07 => new BidKey("bid-" + CEP57Checksum.Encode(bytes.Slice(1))),
+                0x08 => new WithdrawKey("withdraw-" + CEP57Checksum.Encode(bytes.Slice(1))),
+                0x09 => new DictionaryKey("dictionary-" + CEP57Checksum.Encode(bytes.Slice(1))),
+                0x0a => new SystemContractRegistryKey("system-contract-registry-" + CEP57Checksum.Encode(bytes.Slice(1))),
+                0x0b => new EraSummaryKey("era-summary-" + CEP57Checksum.Encode(bytes.Slice(1))),
+                0x0c => new UnbondKey("unbond-" + CEP57Checksum.Encode(bytes.Slice(1))),
+                0x0d => new ChainspecRegistryKey("chainspec-registry-" + CEP57Checksum.Encode(bytes.Slice(1))),
+                0x0e => new ChecksumRegistryKey("checksum-registry-" + CEP57Checksum.Encode(bytes.Slice(1))),
                 _ => throw new ArgumentException($"Unknown key identifier '{bytes[0]}'")
             };
         }

--- a/Casper.Network.SDK/Types/PublicKey.cs
+++ b/Casper.Network.SDK/Types/PublicKey.cs
@@ -93,8 +93,8 @@ namespace Casper.Network.SDK.Types
 
             (int expectedPublicKeySize, string algo) = algoIdent switch
             {
-                0x01 => (KeyAlgo.ED25519.GetKeySizeInBytes(), Enum.GetName(KeyAlgo.ED25519)),
-                0x02 => (KeyAlgo.SECP256K1.GetKeySizeInBytes(), Enum.GetName(KeyAlgo.SECP256K1)),
+                0x01 => (KeyAlgo.ED25519.GetKeySizeInBytes(), EnumCompat.GetName(KeyAlgo.ED25519)),
+                0x02 => (KeyAlgo.SECP256K1.GetKeySizeInBytes(), EnumCompat.GetName(KeyAlgo.SECP256K1)),
                 _ => throw new ArgumentException("Wrong public key algorithm identifier", nameof(bytes))
             };
 

--- a/Casper.Network.SDK/Types/Signature.cs
+++ b/Casper.Network.SDK/Types/Signature.cs
@@ -58,7 +58,7 @@ namespace Casper.Network.SDK.Types
                 _ => throw new ArgumentOutOfRangeException(nameof(bytes), "Wrong signature algorithm identifier")
             };
 
-            return new Signature(bytes[1..], algoIdent);
+            return new Signature(bytes.Slice(1), algoIdent);
         }
 
         /// <summary>

--- a/Casper.Network.SDK/Types/Transform.cs
+++ b/Casper.Network.SDK/Types/Transform.cs
@@ -84,7 +84,7 @@ namespace Casper.Network.SDK.Types
                         {
                             var stype = reader.GetString();
                             if (stype != null)
-                                type = Enum.Parse<TransformType>(stype);
+                                type = EnumCompat.Parse<TransformType>(stype);
                             reader.Read();
                         }
                         else if (reader.TokenType == JsonTokenType.StartObject)
@@ -92,7 +92,7 @@ namespace Casper.Network.SDK.Types
                             reader.Read();
                             var stype = reader.GetString();
                             if (stype != null)
-                                type = Enum.Parse<TransformType>(stype);
+                                type = EnumCompat.Parse<TransformType>(stype);
                             reader.Read();
                             switch (type)
                             {

--- a/Casper.Network.SDK/Types/URef.cs
+++ b/Casper.Network.SDK/Types/URef.cs
@@ -45,7 +45,7 @@ namespace Casper.Network.SDK.Types
         /// Creates an URef from a 33 bytes array. Last byte corresponds to the access rights.
         /// </summary>
         public URef(byte[] bytes)
-            : this($"{KEYPREFIX}{Hex.ToHexString(bytes[..32])}-{(int)bytes[32]:000}")
+            : this($"{KEYPREFIX}{Hex.ToHexString(bytes.Slice(0,32))}-{(int)bytes[32]:000}")
         {
         }
         

--- a/Casper.Network.SDK/Utils/BinaryReaderExtensions.cs
+++ b/Casper.Network.SDK/Utils/BinaryReaderExtensions.cs
@@ -15,7 +15,7 @@ namespace Casper.Network.SDK.Utils
             var bytes = reader.ReadBytes(4);
             if (!BitConverter.IsLittleEndian)
                 Array.Reverse(bytes);
-            return BitConverter.ToInt32(bytes);
+            return BitConverterExtensions.ToInt32(bytes);
         }
 
         public static long ReadCLI64(this BinaryReader reader)
@@ -23,7 +23,7 @@ namespace Casper.Network.SDK.Utils
             var bytes = reader.ReadBytes(8);
             if (!BitConverter.IsLittleEndian)
                 Array.Reverse(bytes);
-            return BitConverter.ToInt64(bytes);
+            return BitConverterExtensions.ToInt64(bytes);
         }
 
         public static byte ReadCLU8(this BinaryReader reader)
@@ -36,7 +36,7 @@ namespace Casper.Network.SDK.Utils
             var bytes = reader.ReadBytes(4);
             if (!BitConverter.IsLittleEndian)
                 Array.Reverse(bytes);
-            return BitConverter.ToUInt32(bytes);
+            return BitConverterExtensions.ToUInt32(bytes);
         }
 
         public static ulong ReadCLU64(this BinaryReader reader)
@@ -44,7 +44,7 @@ namespace Casper.Network.SDK.Utils
             var bytes = reader.ReadBytes(8);
             if (!BitConverter.IsLittleEndian)
                 Array.Reverse(bytes);
-            return BitConverter.ToUInt64(bytes);
+            return BitConverterExtensions.ToUInt64(bytes);
         }
 
         public static BigInteger ReadCLBigInteger(this BinaryReader reader)

--- a/Casper.Network.SDK/Utils/BinaryReaderExtensions.cs
+++ b/Casper.Network.SDK/Utils/BinaryReaderExtensions.cs
@@ -51,7 +51,7 @@ namespace Casper.Network.SDK.Utils
         {
             var length = (int) reader.ReadByte();
             var bytes = reader.ReadBytes(length);
-            return new BigInteger(bytes, true, false);
+            return BigIntegerCompat.Create(bytes, true, false);
         }
 
         public static string ReadCLString(this BinaryReader reader)

--- a/Casper.Network.SDK/Utils/DateUtils.cs
+++ b/Casper.Network.SDK/Utils/DateUtils.cs
@@ -30,7 +30,7 @@ namespace Casper.Network.SDK.Utils
         /// </summary>
         public static string ToISOString(ulong epochTimeInMillis)
         {
-            return DateTime.UnixEpoch
+            return DateTimeCompat.UnixEpoch
                 .AddMilliseconds(epochTimeInMillis)
                 .ToString("yyyy-MM-dd'T'HH:mm:ss.fffK", CultureInfo.InvariantCulture);
         }


### PR DESCRIPTION
### Summary

This PR is a feature branch that allows to build the project for `netstandard2.0` target - making it compatible with Unity:

![image](https://github.com/make-software/casper-net-sdk/assets/121791569/926b5a35-f78a-4342-ad6d-5eb78963bdf4)

![image](https://github.com/make-software/casper-net-sdk/assets/121791569/a78c88b8-2061-44ed-9200-77b75578dc73)

### Checklist

- [x] Code is properly formatted
- [x] All commits are signed
- [x] Tests included/updated or not needed
- [ ] Documentation (manuals or wiki) has been updated or is not required
