### PR TITLE
Fix for GH issue #37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project will be documented in this file.  The format
 [comment]: <> (Fixed:      any bug fixes)
 [comment]: <> (Security:   in case of vulnerabilities)
 
+## [2.1.0]
+
+### Fixed
+* Breaking change! the type for the `Proposer` property in the body block has changed from `PublicKey` to `Proposer`.
+This new type permits to parse correctly the value `"00"` used for system blocks in Casper network starting from v1.5.
+
 ## [2.0.0]
 
 ### Added
@@ -56,6 +62,7 @@ All notable changes to this project will be documented in this file.  The format
 ### Added
 * Initial release of Casper .NET SDK.
 
+[2.1.0]: https://github.com/make-software/casper-net-sdk/releases/tag/v2.1.0
 [2.0.0]: https://github.com/make-software/casper-net-sdk/releases/tag/v2.0.0
 [1.1.2]: https://github.com/make-software/casper-net-sdk/releases/tag/v1.1.2
 [1.1.1]: https://github.com/make-software/casper-net-sdk/releases/tag/v1.1.1

--- a/Casper.Network.SDK.Test/NctlGetXTest.cs
+++ b/Casper.Network.SDK.Test/NctlGetXTest.cs
@@ -187,6 +187,25 @@ namespace NetCasperTest
         }
 
         [Test]
+        public async Task GetSystemBlockProposerTest()
+        {
+            try
+            {
+                var response = await _client.GetBlock(0);
+                var result = response.Parse();
+                Assert.IsNotNull(result.Block.Hash);
+                Assert.IsTrue(result.Block.Body.Proposer.isSystem);
+            }
+            catch (RpcClientException e)
+            {
+                Assert.IsNotNull(e.RpcError);
+                Assert.IsNotNull(e.RpcError.Message);
+                Assert.AreNotEqual(0, e.RpcError.Code);
+                Assert.IsNotNull(e.RpcError.Data);
+            }
+        }
+
+        [Test]
         public async Task GetAuctionInfoTest()
         {
             try

--- a/Casper.Network.SDK/Casper.Network.SDK.csproj
+++ b/Casper.Network.SDK/Casper.Network.SDK.csproj
@@ -2,9 +2,9 @@
 
     <PropertyGroup>
         <TargetFramework>net7.0</TargetFramework>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-        <FileVersion>2.0.0</FileVersion>
-        <PackageVersion>2.0.0</PackageVersion>
+        <AssemblyVersion>2.1.0.0</AssemblyVersion>
+        <FileVersion>2.1.0</FileVersion>
+        <PackageVersion>2.1.0</PackageVersion>
         <Title>Casper.Network.SDK</Title>
         <Authors>make-software</Authors>
         <PackageProjectUrl>https://github.com/make-software/casper-net-sdk</PackageProjectUrl>

--- a/Casper.Network.SDK/Types/Block.cs
+++ b/Casper.Network.SDK/Types/Block.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Casper.Network.SDK.Types
@@ -70,6 +72,61 @@ namespace Casper.Network.SDK.Types
     }
 
     /// <summary>
+    /// Validator that proposed the block
+    /// </summary>
+    public class Proposer
+    {
+        /// <summary>
+        /// The block was proposed by the system, not a validator
+        /// </summary>
+        public bool isSystem { get; set; }
+        
+        /// <summary>
+        /// Validator's public key
+        /// </summary>
+        public PublicKey PublicKey { get; set; }
+        
+        /// <summary>
+        /// Json converter class to serialize/deserialize a Proposer to/from Json
+        /// </summary>
+        public class ProposerConverter : JsonConverter<Proposer>
+        {
+            public override Proposer Read(
+                ref Utf8JsonReader reader,
+                Type typeToConvert,
+                JsonSerializerOptions options)
+            {
+                try
+                {
+                    var pkhex = reader.GetString();
+                    if (pkhex == "00")
+                        return new Proposer()
+                        {
+                            isSystem = true,
+                        };
+                    return new Proposer()
+                    {
+                        isSystem = false,
+                        PublicKey = PublicKey.FromHexString(pkhex),
+                    };
+                }
+                catch (Exception e)
+                {
+                    throw new JsonException(e.Message);
+                }
+            }
+
+            public override void Write(
+                Utf8JsonWriter writer,
+                Proposer proposer,
+                JsonSerializerOptions options)
+            {
+                writer.WriteStringValue(proposer.isSystem ? "00" : proposer.PublicKey.ToAccountHex());
+            }
+        }
+    }
+    
+    /// <summary>
     /// A block body
     /// </summary>
     public class BlockBody
@@ -84,8 +141,8 @@ namespace Casper.Network.SDK.Types
         /// Public key of the validator that proposed the block
         /// </summary>
         [JsonPropertyName("proposer")]
-        [JsonConverter(typeof(PublicKey.PublicKeyConverter))]
-        public PublicKey Proposer { get; init; }
+        [JsonConverter(typeof(Proposer.ProposerConverter))]
+        public Proposer Proposer { get; init; }
         
         /// <summary>
         /// List of Transfer hashes included in the block


### PR DESCRIPTION
* Resolves: #37 

### Summary

The type for the `Proposer` property in the body block has changed from `PublicKey` to `Proposer`.
This new type permits to parse correctly the value `"00"` used for system blocks in Casper network starting from v1.5.

### TODO

- [ ] ...

### Checklist

- [X] Code is properly formatted
- [X] All commits are signed
- [X] Tests included/updated or not needed
- [X] Documentation (manuals or wiki) has been updated or is not required


