### PR TITLE
Fixes isSystem typo.

### DIFF
--- a/Casper.Network.SDK.Test/NctlGetXTest.cs
+++ b/Casper.Network.SDK.Test/NctlGetXTest.cs
@@ -161,7 +161,9 @@ namespace NetCasperTest
                 var response2 = await _client.GetBlock(1);
                 var result2 = response2.Parse();
                 Assert.IsNotNull(result2.Block.Hash);
-
+                
+                Assert.AreEqual(result2.Block.Body.Proposer.IsSystem, result2.Block.Body.Proposer.isSystem);
+                
                 var response3 = await _client.GetBlock(result2.Block.Hash);
                 var result3 = response3.Parse();
                 Assert.AreEqual(result2.Block.Hash, result3.Block.Hash);
@@ -214,7 +216,8 @@ namespace NetCasperTest
                 var response = await _client.GetBlock(0);
                 var result = response.Parse();
                 Assert.IsNotNull(result.Block.Hash);
-                Assert.IsTrue(result.Block.Body.Proposer.isSystem);
+                Assert.IsTrue(result.Block.Body.Proposer.IsSystem);
+                Assert.AreEqual(result.Block.Body.Proposer.IsSystem, result.Block.Body.Proposer.isSystem);
             }
             catch (RpcClientException e)
             {

--- a/Casper.Network.SDK/Types/Block.cs
+++ b/Casper.Network.SDK/Types/Block.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -79,7 +80,15 @@ namespace Casper.Network.SDK.Types
         /// <summary>
         /// The block was proposed by the system, not a validator
         /// </summary>
-        public bool isSystem { get; set; }
+        public bool IsSystem { get; set; }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Replaced with IsSystem")]
+        public bool isSystem
+        {
+            get => this.IsSystem;
+            set => this.IsSystem = value;
+        }
         
         /// <summary>
         /// Validator's public key
@@ -102,11 +111,11 @@ namespace Casper.Network.SDK.Types
                     if (pkhex == "00")
                         return new Proposer()
                         {
-                            isSystem = true,
+                            IsSystem = true,
                         };
                     return new Proposer()
                     {
-                        isSystem = false,
+                        IsSystem = false,
                         PublicKey = PublicKey.FromHexString(pkhex),
                     };
                 }
@@ -121,7 +130,7 @@ namespace Casper.Network.SDK.Types
                 Proposer proposer,
                 JsonSerializerOptions options)
             {
-                writer.WriteStringValue(proposer.isSystem ? "00" : proposer.PublicKey.ToAccountHex());
+                writer.WriteStringValue(proposer.IsSystem ? "00" : proposer.PublicKey.ToAccountHex());
             }
         }
     }


### PR DESCRIPTION
### Summary

`isSystem` property marked as obsolete and replaced with `IsSystem`.

### TODO

n/a

### Checklist

- [X] Code is properly formatted
- [X] All commits are signed
- [X] Tests included/updated or not needed
- [X] Documentation (manuals or wiki) has been updated or is not required


