### PR TITLE
Use `ToLowerInvariant()` to avoid CultureInfo issues

### DIFF
--- a/Casper.Network.SDK.Test/NctlContractTest.cs
+++ b/Casper.Network.SDK.Test/NctlContractTest.cs
@@ -33,7 +33,7 @@ namespace NetCasperTest
                 50_000_000_000,
                 _chainName,
                 1, //gasPrice=1
-                45011500); //ttl='12h 30m 11s 500ms'
+                3_600_000*2); //ttl='2h'
             deploy.Sign(_faucetKey);
 
             var putResponse = await _client.PutDeploy(deploy);
@@ -92,7 +92,7 @@ namespace NetCasperTest
                 150_000_000,
                 _chainName,
                 1, //gasPrice=1
-                18*3_600_000); //ttl='18h'
+                2*3_600_000); //ttl='2h'
             deploy.Sign(_faucetKey);
 
             var putResponse = await _client.PutDeploy(deploy);

--- a/Casper.Network.SDK.Test/NctlSpeculativeExecutionTest.cs
+++ b/Casper.Network.SDK.Test/NctlSpeculativeExecutionTest.cs
@@ -48,7 +48,7 @@ namespace NetCasperTest
                 50_000_000_000,
                 _chainName,
                 1, //gasPrice=1
-                45011500); //ttl='12h 30m 11s 500ms'
+                3_600_000*2); //ttl='2h'
             deploy.Sign(_faucetKey);
 
             var rpcResponse = await _client.SpeceulativeExecution(deploy);

--- a/Casper.Network.SDK/SSE/ServerEventsClient.cs
+++ b/Casper.Network.SDK/SSE/ServerEventsClient.cs
@@ -276,7 +276,7 @@ namespace Casper.Network.SDK.SSE
                     try
                     {
                         var uriBuilder = new UriBuilder(new Uri(client.BaseAddress +
-                            $"events/{channelType.ToString().ToLower()}"));
+                            $"events/{channelType.ToString().ToLowerInvariant()}"));
 
                         if (startFrom != null && startFrom != int.MaxValue)
                             uriBuilder.Query = $"start_from={startFrom}";

--- a/Casper.Network.SDK/Types/Delegator.cs
+++ b/Casper.Network.SDK/Types/Delegator.cs
@@ -67,10 +67,10 @@ namespace Casper.Network.SDK.Types
                 
                 while (reader.TokenType == JsonTokenType.PropertyName)
                 {
-                    var property = reader.GetString();
+                    var property = reader.GetString()?.ToLowerInvariant();
                     reader.Read();
                     
-                    switch (property.ToLower())
+                    switch (property)
                     {
                         case "delegator_public_key":
                         case "public_key":

--- a/Casper.Network.SDK/Types/EntryPoint.cs
+++ b/Casper.Network.SDK/Types/EntryPoint.cs
@@ -32,7 +32,7 @@ namespace Casper.Network.SDK.Types
                 if (reader.TokenType == JsonTokenType.String)
                 {
                     var value = reader.GetString();
-                    if (value.ToLower() == "public")
+                    if (value.ToLowerInvariant() == "public")
                         return new EntryPointAccess()
                         {
                             IsPublic = true,
@@ -44,7 +44,7 @@ namespace Casper.Network.SDK.Types
                     reader.Read(); // start object
                     var value = reader.GetString(); // read property
                     reader.Read();
-                    if (value.ToLower() == "groups")
+                    if (value.ToLowerInvariant() == "groups")
                     {
                         List<string> groups = JsonSerializer.Deserialize<List<string>>(ref reader, options);
                         reader.Read(); // end array

--- a/Casper.Network.SDK/Types/ExecutionResult.cs
+++ b/Casper.Network.SDK/Types/ExecutionResult.cs
@@ -70,7 +70,7 @@ namespace Casper.Network.SDK.Types
                     var property = reader.GetString();
                     reader.Read();
 
-                    switch (property.ToLower())
+                    switch (property.ToLowerInvariant())
                     {
                         case "block_hash":
                             blockHash = reader.GetString();

--- a/Casper.Network.SDK/Types/PublicKey.cs
+++ b/Casper.Network.SDK/Types/PublicKey.cs
@@ -168,7 +168,7 @@ namespace Casper.Network.SDK.Types
         public string GetAccountHash()
         {
             var bcBl2bdigest = new Org.BouncyCastle.Crypto.Digests.Blake2bDigest(256);
-            string algo = KeyAlgorithm.ToString().ToLower();
+            string algo = KeyAlgorithm.ToString().ToLowerInvariant();
             bcBl2bdigest.BlockUpdate(System.Text.Encoding.UTF8.GetBytes(algo), 0, algo.Length);
             bcBl2bdigest.Update(0x00);
             bcBl2bdigest.BlockUpdate(RawBytes, 0, RawBytes.Length);

--- a/Casper.Network.SDK/Types/SeigniorageAllocation.cs
+++ b/Casper.Network.SDK/Types/SeigniorageAllocation.cs
@@ -74,7 +74,7 @@ namespace Casper.Network.SDK.Types
 
                 return new SeigniorageAllocation()
                 {
-                    IsDelegator = propertyName?.ToLower() == "delegator",
+                    IsDelegator = propertyName?.ToLowerInvariant() == "delegator",
                     DelegatorPublicKey = delegatorPk != null ? PublicKey.FromHexString(delegatorPk) : null,
                     ValidatorPublicKey = PublicKey.FromHexString(validatorPk),
                     Amount = amount

--- a/Casper.Network.SDK/Types/StoredValue.cs
+++ b/Casper.Network.SDK/Types/StoredValue.cs
@@ -45,10 +45,10 @@ namespace Casper.Network.SDK.Types
                 if (reader.TokenType != JsonTokenType.PropertyName)
                     throw new JsonException("Cannot deserialize StoredValue. PropertyName expected");
 
-                var propertyName = reader.GetString();
+                var propertyName = reader.GetString()?.ToLowerInvariant();
                 reader.Read();
 
-                if (propertyName.ToLower() == "contract")
+                if (propertyName == "contract")
                 {
                     var contract = JsonSerializer.Deserialize<Contract>(ref reader, options);
                     reader.Read(); // end Contract object
@@ -57,7 +57,7 @@ namespace Casper.Network.SDK.Types
                         Contract = contract
                     };
                 }
-                else if (propertyName.ToLower() == "clvalue")
+                else if (propertyName == "clvalue")
                 {
                     var clValue = JsonSerializer.Deserialize<CLValue>(ref reader, options);
                     reader.Read(); // end CLValue object
@@ -66,7 +66,7 @@ namespace Casper.Network.SDK.Types
                         CLValue = clValue
                     };
                 }
-                else if (propertyName.ToLower() == "account")
+                else if (propertyName == "account")
                 {
                     var account = JsonSerializer.Deserialize<Account>(ref reader, options);
                     reader.Read(); // end Account object
@@ -75,7 +75,7 @@ namespace Casper.Network.SDK.Types
                         Account = account
                     };
                 }
-                else if (propertyName.ToLower() == "contractwasm")
+                else if (propertyName == "contractwasm")
                 {
                     var wasmBytes = reader.GetString();
                     reader.Read(); // wasm bytes
@@ -84,7 +84,7 @@ namespace Casper.Network.SDK.Types
                         ContractWasm = wasmBytes
                     };
                 }
-                else if (propertyName.ToLower() == "contractpackage")
+                else if (propertyName == "contractpackage")
                 {
                     var contractPackage = JsonSerializer.Deserialize<ContractPackage>(ref reader, options);
                     reader.Read(); // end ContractPackage object
@@ -93,7 +93,7 @@ namespace Casper.Network.SDK.Types
                         ContractPackage = contractPackage
                     };
                 }
-                else if (propertyName.ToLower() == "transfer")
+                else if (propertyName == "transfer")
                 {
                     var transfer = JsonSerializer.Deserialize<Transfer>(ref reader, options);
                     reader.Read(); // end Transfer object
@@ -102,7 +102,7 @@ namespace Casper.Network.SDK.Types
                         Transfer = transfer
                     };
                 }
-                else if (propertyName.ToLower() == "deployinfo")
+                else if (propertyName == "deployinfo")
                 {
                     var deployInfo = JsonSerializer.Deserialize<DeployInfo>(ref reader, options);
                     reader.Read(); // end DeployInfo object
@@ -111,7 +111,7 @@ namespace Casper.Network.SDK.Types
                         DeployInfo = deployInfo
                     };
                 }
-                else if (propertyName.ToLower() == "erainfo")
+                else if (propertyName == "erainfo")
                 {
                     var eraInfo = JsonSerializer.Deserialize<EraInfo>(ref reader, options);
                     reader.Read(); // end EraInfo object
@@ -120,7 +120,7 @@ namespace Casper.Network.SDK.Types
                         EraInfo = eraInfo
                     };
                 }
-                else if (propertyName.ToLower() == "bid")
+                else if (propertyName == "bid")
                 {
                     var bid = JsonSerializer.Deserialize<Bid>(ref reader, options);
                     reader.Read(); // end Bid object
@@ -129,7 +129,7 @@ namespace Casper.Network.SDK.Types
                         Bid = bid
                     };
                 }
-                else if (propertyName.ToLower() == "withdraw")
+                else if (propertyName == "withdraw")
                 {
                     var withdraw = JsonSerializer.Deserialize<List<UnbondingPurse>>(ref reader, options);
                     reader.Read(); // end Withdraw object


### PR DESCRIPTION
### Summary
`ToLower()` is causing problems when converting words like `EraInfo` in some cultures. 

### TODO

n/a

### Checklist

- [X] Code is properly formatted
- [X] All commits are signed
- [X] Tests included/updated or not needed
- [X] Documentation (manuals or wiki) has been updated or is not required
