### PR TITLE
Replace int with ulong for blockheight arguments

### DIFF
--- a/Casper.Network.SDK.Test/NctlGetXTest.cs
+++ b/Casper.Network.SDK.Test/NctlGetXTest.cs
@@ -47,7 +47,7 @@ namespace NetCasperTest
             try
             {
                 var block = (await _client.GetBlock()).Parse().Block;
-                var blockHeight = (int) block.Height;
+                var blockHeight = block.Height;
                 var blockHash = block.Hash;
                 var stateRootHash = await _client.GetStateRootHash(blockHash);
 
@@ -147,13 +147,13 @@ namespace NetCasperTest
                 var result2 = response2.Parse();
                 Assert.IsNotNull(result2.Block.Hash);
                 
-                Assert.AreEqual(result2.Block.Proposer.IsSystem, result2.Block.Proposer.isSystem);
+                Assert.AreEqual(result2.Block.Proposer.IsSystem, result2.Block.Proposer.IsSystem);
                 
                 var response3 = await _client.GetBlock(result2.Block.Hash);
                 var result3 = response3.Parse();
                 Assert.AreEqual(result2.Block.Hash, result3.Block.Hash);
 
-                var response4 = await _client.GetBlock((int)result2.Block.Height);
+                var response4 = await _client.GetBlock(result2.Block.Height);
                 var result4 = response4.Parse();
                 Assert.AreEqual(result2.Block.Hash, result4.Block.Hash);
 
@@ -161,14 +161,14 @@ namespace NetCasperTest
                 var result5 = response5.Parse();
                 Assert.AreEqual(0, result5.Transfers.Count);
                 
-                var response6 = await _client.GetBlockTransfers((int)result2.Block.Height);
+                var response6 = await _client.GetBlockTransfers(result2.Block.Height);
                 var result6 = response6.Parse();
                 Assert.AreEqual(0, result6.Transfers.Count);
                 
                 var hash1 = await _client.GetStateRootHash(result2.Block.Hash);
                 Assert.AreEqual(32*2, hash1.Length);
 
-                var hash2 = await _client.GetStateRootHash((int)result2.Block.Height);
+                var hash2 = await _client.GetStateRootHash(result2.Block.Height);
                 Assert.AreEqual(hash1, hash2);
                 
                 var hash3 = await _client.GetStateRootHash();
@@ -202,7 +202,7 @@ namespace NetCasperTest
                 var result = response.Parse();
                 Assert.IsNotNull(result.Block.Hash);
                 Assert.IsTrue(result.Block.Proposer.IsSystem);
-                Assert.AreEqual(result.Block.Proposer.IsSystem, result.Block.Proposer.isSystem);
+                Assert.AreEqual(result.Block.Proposer.IsSystem, result.Block.Proposer.IsSystem);
             }
             catch (RpcClientException e)
             {
@@ -261,7 +261,7 @@ namespace NetCasperTest
                 var result3 = response3.Parse();
                 Assert.IsNotNull(result3.Block.Hash);
                 
-                var response4 = await _client.GetEraSummary((int)result3.Block.Height);
+                var response4 = await _client.GetEraSummary(result3.Block.Height);
                 var result4 = response4.Parse();
                 Assert.IsTrue(result4.EraSummary.EraId > 0);
                 Assert.IsNotNull(result4.EraSummary.StoredValue.EraInfo);

--- a/Casper.Network.SDK/ICasperClient.cs
+++ b/Casper.Network.SDK/ICasperClient.cs
@@ -10,7 +10,7 @@ namespace Casper.Network.SDK
     {
         Task<string> GetStateRootHash(string blockHash = null);
 
-        Task<string> GetStateRootHash(int blockHeight);
+        Task<string> GetStateRootHash(ulong blockHeight);
 
         Task<RpcResponse<GetNodeStatusResult>> GetNodeStatus();
 
@@ -18,19 +18,19 @@ namespace Casper.Network.SDK
 
         Task<RpcResponse<GetAuctionInfoResult>> GetAuctionInfo(string blockHash = null);
 
-        Task<RpcResponse<GetAuctionInfoResult>> GetAuctionInfo(int blockHeight);
+        Task<RpcResponse<GetAuctionInfoResult>> GetAuctionInfo(ulong blockHeight);
 
         Task<RpcResponse<GetAccountInfoResult>> GetAccountInfo(PublicKey publicKey, string blockHash = null);
 
         Task<RpcResponse<GetAccountInfoResult>> GetAccountInfo(string publicKey, string blockHash = null);
 
-        Task<RpcResponse<GetAccountInfoResult>> GetAccountInfo(PublicKey publicKey, int blockHeight);
+        Task<RpcResponse<GetAccountInfoResult>> GetAccountInfo(PublicKey publicKey, ulong blockHeight);
 
-        Task<RpcResponse<GetAccountInfoResult>> GetAccountInfo(string publicKey, int blockHeight);
+        Task<RpcResponse<GetAccountInfoResult>> GetAccountInfo(string publicKey, ulong blockHeight);
 
         Task<RpcResponse<GetAccountInfoResult>> GetAccountInfo(AccountHashKey accountHash, string blockHash = null);
 
-        Task<RpcResponse<GetAccountInfoResult>> GetAccountInfo(AccountHashKey accountHash, int blockHeight);
+        Task<RpcResponse<GetAccountInfoResult>> GetAccountInfo(AccountHashKey accountHash, ulong blockHeight);
 
         Task<RpcResponse<GetEntityResult>> GetEntity(IEntityIdentifier entityIdentifier, string blockHash = null);
 
@@ -40,6 +40,8 @@ namespace Casper.Network.SDK
 
         Task<RpcResponse<GetEntityResult>> GetEntity(string entityAddr, ulong blockHeight);
 
+        Task<RpcResponse<QueryGlobalStateResult>> QueryGlobalState(string key, ulong height,
+            string path = null);
         Task<RpcResponse<QueryGlobalStateResult>> QueryGlobalState(string key, string stateRootHash = null,
             string path = null);
         
@@ -77,23 +79,37 @@ namespace Casper.Network.SDK
 
         Task<RpcResponse<GetDeployResult>> GetDeploy(string deployHash,
             CancellationToken cancellationToken = default(CancellationToken));
+
+        Task<RpcResponse<GetDeployResult>> GetDeploy(string deployHash,
+            bool finalizedApprovals,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        Task<RpcResponse<PutTransactionResult>> PutTransaction(TransactionV1 transaction);
         
         Task<RpcResponse<GetTransactionResult>> GetTransaction(TransactionHash transactionHash,
+            bool finalizedApprovals = false,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        Task<RpcResponse<GetTransactionResult>> GetTransaction(string version1Hash,
             bool finalizedApprovals = false,
             CancellationToken cancellationToken = default(CancellationToken));
         
         Task<RpcResponse<GetBlockResult>> GetBlock(string blockHash = null);
 
-        Task<RpcResponse<GetBlockResult>> GetBlock(int blockHeight);
+        Task<RpcResponse<GetBlockResult>> GetBlock(ulong blockHeight);
 
         Task<RpcResponse<GetBlockTransfersResult>> GetBlockTransfers(string blockHash = null);
         
-        Task<RpcResponse<GetBlockTransfersResult>> GetBlockTransfers(int blockHeight);
+        Task<RpcResponse<GetBlockTransfersResult>> GetBlockTransfers(ulong blockHeight);
 
         Task<RpcResponse<GetEraInfoBySwitchBlockResult>> GetEraInfoBySwitchBlock(string blockHash = null);
 
-        Task<RpcResponse<GetEraInfoBySwitchBlockResult>> GetEraInfoBySwitchBlock(int blockHeight);
+        Task<RpcResponse<GetEraInfoBySwitchBlockResult>> GetEraInfoBySwitchBlock(ulong blockHeight);
 
+        Task<RpcResponse<GetEraSummaryResult>> GetEraSummary(string blockHash = null);
+
+        Task<RpcResponse<GetEraSummaryResult>> GetEraSummary(ulong blockHeight);
+        
         Task<RpcResponse<GetDictionaryItemResult>> GetDictionaryItem(string dictionaryItem, string stateRootHash = null);
 
         Task<RpcResponse<GetDictionaryItemResult>> GetDictionaryItemByAccount(string accountKey, string dictionaryName,
@@ -108,5 +124,11 @@ namespace Casper.Network.SDK
         Task<RpcResponse<GetValidatorChangesResult>> GetValidatorChanges();
 
         Task<string> GetRpcSchema();
+
+        Task<RpcResponse<GetChainspecResult>> GetChainspec();
+
+        Task<RpcResponse<SpeculativeExecutionResult>> SpeceulativeExecution(Deploy deploy, string stateRootHash = null);
+
+        Task<RpcResponse<PutDeployResult>> SpeceulativeExecutionWithBlockHash(Deploy deploy, string blockHash = null);
     }
 }

--- a/Casper.Network.SDK/JsonRpc/CasperMethods.cs
+++ b/Casper.Network.SDK/JsonRpc/CasperMethods.cs
@@ -20,7 +20,7 @@ namespace Casper.Network.SDK.JsonRpc
         /// Returns the state root hash at a given Block
         /// </summary>
         /// <param name="height">Block height for which the state root is queried.</param>
-        public GetStateRootHash(int height) : base("chain_get_state_root_hash", height)
+        public GetStateRootHash(ulong height) : base("chain_get_state_root_hash", height)
         {
         }
     }
@@ -59,7 +59,7 @@ namespace Casper.Network.SDK.JsonRpc
         /// Returns the bids and validators at a given block.
         /// </summary>
         /// <param name="height">Block height for which the auction info is queried.</param>
-        public GetAuctionInfo(int height) : base("state_get_auction_info", height)
+        public GetAuctionInfo(ulong height) : base("state_get_auction_info", height)
         {
         }
     }
@@ -81,7 +81,7 @@ namespace Casper.Network.SDK.JsonRpc
         /// </summary>
         /// <param name="publicKey">The public key of the account.</param>
         /// <param name="height">A block height for which the information of the account is queried.</param>
-        public GetAccountInfo(PublicKey publicKey, int height) : base("state_get_account_info", height)
+        public GetAccountInfo(PublicKey publicKey, ulong height) : base("state_get_account_info", height)
         {
             this.Parameters.Add("account_identifier", publicKey);
         }
@@ -101,7 +101,7 @@ namespace Casper.Network.SDK.JsonRpc
         /// </summary>
         /// <param name="accountHash">The account hash of the account.</param>
         /// <param name="height">A block height for which the information of the account is queried.</param>
-        public GetAccountInfo(AccountHashKey accountHash, int height) : base("state_get_account_info", height)
+        public GetAccountInfo(AccountHashKey accountHash, ulong height) : base("state_get_account_info", height)
         {
             // this.Parameters.Add("account_identifier", Hex.ToHexString(accountHash.GetBytes()));
             this.Parameters.Add("account_identifier", accountHash.ToString());
@@ -124,7 +124,7 @@ namespace Casper.Network.SDK.JsonRpc
         /// <param name="publicKey">The public key of the account.</param>
         /// <param name="height">A block height for which the information of the account is queried.</param>
         [Obsolete("For Casper node v1.5.5 or newer use the new method signature with PublicKey or AccountHashKey", false)]
-        public GetAccountInfo(string publicKey, int height) : base("state_get_account_info", height)
+        public GetAccountInfo(string publicKey, ulong height) : base("state_get_account_info", height)
         {
             this.Parameters.Add("public_key", publicKey);
         }
@@ -358,7 +358,7 @@ namespace Casper.Network.SDK.JsonRpc
         /// Retrieves a Block from the network by its height number.
         /// </summary>
         /// <param name="height">Height of the block to retrieve.</param>
-        public GetBlock(int height) : base("chain_get_block", height)
+        public GetBlock(ulong height) : base("chain_get_block", height)
         {
         }
     }
@@ -377,7 +377,7 @@ namespace Casper.Network.SDK.JsonRpc
         /// Retrieves all transfers for a Block from the network
         /// </summary>
         /// <param name="height">Height of the block to retrieve the transfers from.</param>
-        public GetBlockTransfers(int height) : base("chain_get_block_transfers", height)
+        public GetBlockTransfers(ulong height) : base("chain_get_block_transfers", height)
         {
         }
     }
@@ -396,7 +396,7 @@ namespace Casper.Network.SDK.JsonRpc
         /// Retrieves an EraInfo from the network given a switch block.
         /// </summary>
         /// <param name="height">Block height of a switch block.</param>
-        public GetEraInfoBySwitchBlock(int height) : base("chain_get_era_info_by_switch_block", height)
+        public GetEraInfoBySwitchBlock(ulong height) : base("chain_get_era_info_by_switch_block", height)
         {
         }
     }
@@ -415,7 +415,7 @@ namespace Casper.Network.SDK.JsonRpc
         /// Retrieves current era info from the network given a block height 
         /// </summary>
         /// <param name="height">Block height.</param>
-        public GetEraSummary(int height) : base("chain_get_era_summary", height)
+        public GetEraSummary(ulong height) : base("chain_get_era_summary", height)
         {
         }
     }

--- a/Casper.Network.SDK/JsonRpc/RpcMethod.cs
+++ b/Casper.Network.SDK/JsonRpc/RpcMethod.cs
@@ -76,11 +76,11 @@ namespace Casper.Network.SDK.JsonRpc
             };
         }
 
-        public RpcMethod(string method, int blockHeight)
+        public RpcMethod(string method, ulong blockHeight)
         {
             this.Method = method;
 
-            var blockIdentifier = new Dictionary<string, int>
+            var blockIdentifier = new Dictionary<string, ulong>
             {
                 {"Height", blockHeight}
             };

--- a/Casper.Network.SDK/NetCasperClient.cs
+++ b/Casper.Network.SDK/NetCasperClient.cs
@@ -61,7 +61,7 @@ namespace Casper.Network.SDK
         /// </summary>
         /// <param name="blockHeight">Block height for which the state root is queried.</param>
         /// <returns></returns>
-        public async Task<string> GetStateRootHash(int blockHeight)
+        public async Task<string> GetStateRootHash(ulong blockHeight)
         {
             var method = new GetStateRootHash(blockHeight);
             var rpcResponse = await SendRpcRequestAsync<GetStateRootHashResult>(method);
@@ -101,7 +101,7 @@ namespace Casper.Network.SDK
         /// Request the bids and validators at a given block. 
         /// </summary>
         /// <param name="blockHeight">Block height for which the auction info is queried.</param>
-        public async Task<RpcResponse<GetAuctionInfoResult>> GetAuctionInfo(int blockHeight)
+        public async Task<RpcResponse<GetAuctionInfoResult>> GetAuctionInfo(ulong blockHeight)
         {
             var method = new GetAuctionInfo(blockHeight);
             return await SendRpcRequestAsync<GetAuctionInfoResult>(method);
@@ -149,7 +149,7 @@ namespace Casper.Network.SDK
         /// </summary>
         /// <param name="publicKey">The public key of the account.</param>
         /// <param name="blockHeight">A block height for which the information of the account is queried.</param>
-        public async Task<RpcResponse<GetAccountInfoResult>> GetAccountInfo(PublicKey publicKey, int blockHeight)
+        public async Task<RpcResponse<GetAccountInfoResult>> GetAccountInfo(PublicKey publicKey, ulong blockHeight)
         {
             var method = new GetAccountInfo(publicKey, blockHeight);
             return await SendRpcRequestAsync<GetAccountInfoResult>(method);
@@ -160,7 +160,7 @@ namespace Casper.Network.SDK
         /// </summary>
         /// <param name="accountHash">The account hash of the account.</param>
         /// <param name="blockHeight">A block height for which the information of the account is queried.</param>
-        public async Task<RpcResponse<GetAccountInfoResult>> GetAccountInfo(AccountHashKey accountHash, int blockHeight)
+        public async Task<RpcResponse<GetAccountInfoResult>> GetAccountInfo(AccountHashKey accountHash, ulong blockHeight)
         {
             var method = new GetAccountInfo(accountHash, blockHeight);
             return await SendRpcRequestAsync<GetAccountInfoResult>(method);
@@ -172,7 +172,7 @@ namespace Casper.Network.SDK
         /// <param name="publicKey">The public key of the account formatted as an hex-string.</param>
         /// <param name="blockHeight">A block height for which the information of the account is queried.</param>
         [Obsolete("For Casper node v1.5.5 or newer use the new method signature with PublicKey or AccountHashKey, ", false)]
-        public async Task<RpcResponse<GetAccountInfoResult>> GetAccountInfo(string publicKey, int blockHeight)
+        public async Task<RpcResponse<GetAccountInfoResult>> GetAccountInfo(string publicKey, ulong blockHeight)
         {
             var method = new GetAccountInfo(publicKey, blockHeight);
             return await SendRpcRequestAsync<GetAccountInfoResult>(method);
@@ -537,7 +537,7 @@ namespace Casper.Network.SDK
         /// Request a Block from the network by its height number.
         /// </summary>
         /// <param name="blockHeight">Height of the block to retrieve.</param>
-        public async Task<RpcResponse<GetBlockResult>> GetBlock(int blockHeight)
+        public async Task<RpcResponse<GetBlockResult>> GetBlock(ulong blockHeight)
         {
             var method = new GetBlock(blockHeight);
             return await SendRpcRequestAsync<GetBlockResult>(method);
@@ -557,7 +557,7 @@ namespace Casper.Network.SDK
         /// Request all transfers for a Block by its height number.
         /// </summary>
         /// <param name="blockHeight">Height of the block to retrieve the transfers from.</param>
-        public async Task<RpcResponse<GetBlockTransfersResult>> GetBlockTransfers(int blockHeight)
+        public async Task<RpcResponse<GetBlockTransfersResult>> GetBlockTransfers(ulong blockHeight)
         {
             var method = new GetBlockTransfers(blockHeight);
             return await SendRpcRequestAsync<GetBlockTransfersResult>(method);
@@ -579,7 +579,7 @@ namespace Casper.Network.SDK
         /// For a non-switch block this method returns an empty response.
         /// </summary>
         /// <param name="blockHeight">Block height of a switch block.</param>
-        public async Task<RpcResponse<GetEraInfoBySwitchBlockResult>> GetEraInfoBySwitchBlock(int blockHeight)
+        public async Task<RpcResponse<GetEraInfoBySwitchBlockResult>> GetEraInfoBySwitchBlock(ulong blockHeight)
         {
             var method = new GetEraInfoBySwitchBlock(blockHeight);
             return await SendRpcRequestAsync<GetEraInfoBySwitchBlockResult>(method);
@@ -599,7 +599,7 @@ namespace Casper.Network.SDK
         /// Request current Era Info from the network given a block hash
         /// </summary>
         /// <param name="blockHeight">Block height.</param>
-        public async Task<RpcResponse<GetEraSummaryResult>> GetEraSummary(int blockHeight)
+        public async Task<RpcResponse<GetEraSummaryResult>> GetEraSummary(ulong blockHeight)
         {
             var method = new GetEraSummary(blockHeight);
             return await SendRpcRequestAsync<GetEraSummaryResult>(method);


### PR DESCRIPTION
### Summary

There was a mix of int and ulong types used for block heights. this PR replaces all `int` with `ulong`.
Used `IsSystem` instead of `isSystem` (which was marked as obsolete in a previous version).

### TODO

### Checklist

- [X] Code is properly formatted
- [X] All commits are signed
- [X] Tests included/updated or not needed
- [X] Documentation (manuals or wiki) has been updated or is not required


