### PR TITLE
CSDK-189 added protocol_version to get node status response

### DIFF
--- a/Casper.Network.SDK.Test/RPCResponses/GetNodeStatusResultTest.cs
+++ b/Casper.Network.SDK.Test/RPCResponses/GetNodeStatusResultTest.cs
@@ -16,7 +16,8 @@ namespace NetCasperTest.RPCResponses
 
             var result = RpcResult.Parse<GetNodeStatusResult>(json);
             Assert.IsNotNull(result);
-            Assert.AreEqual("2.0.0", result.ApiVersion);
+            Assert.AreEqual("1.2.3", result.ApiVersion);
+            Assert.AreEqual("5.4.3", result.ProtocolVersion);
             Assert.AreEqual(4, result.Peers.Count);
             Assert.IsNotNull(result.Peers[1].NodeId);            
             Assert.IsNotNull(result.Peers[1].Address);   

--- a/Casper.Network.SDK.Test/TestData/info-get-status-v200.json
+++ b/Casper.Network.SDK.Test/TestData/info-get-status-v200.json
@@ -1,5 +1,6 @@
 {
-  "api_version": "2.0.0",
+  "api_version": "1.2.3",
+  "protocol_version": "5.4.3",
   "peers": [
     {
       "node_id": "tls:0eae..e79e",

--- a/Casper.Network.SDK/JsonRpc/ResultTypes/GetNodeStatusResult.cs
+++ b/Casper.Network.SDK/JsonRpc/ResultTypes/GetNodeStatusResult.cs
@@ -85,5 +85,11 @@ namespace Casper.Network.SDK.JsonRpc.ResultTypes
         /// The hash of the latest switch block.
         /// </summary>
         [JsonPropertyName("latest_switch_block_hash")] public string LatestSwitchBlockHash { get; init; }
+        
+        /// <summary>
+        /// The protocol version running in the node
+        /// </summary>
+        [JsonPropertyName("protocol_version")]
+        public string ProtocolVersion { get; init; }
     }
 }


### PR DESCRIPTION
### Summary

Added `ProtocolVersion` to `GetNodeResult` class. This new property is added in https://github.com/casper-network/casper-node/pull/4787 (part of RC4)

### TODO

### Checklist

- [X] Code is properly formatted
- [X] All commits are signed
- [X] Tests included/updated or not needed
- [X] Documentation (manuals or wiki) has been updated or is not required


