### PR TITLE
Add get auction info v2 support.

### DIFF
--- a/Casper.Network.SDK.Test/RPCResponses/GetAuctionInfoResultTest.cs
+++ b/Casper.Network.SDK.Test/RPCResponses/GetAuctionInfoResultTest.cs
@@ -28,11 +28,11 @@ namespace NetCasperTest.RPCResponses
             Assert.AreEqual(BigInteger.Parse("10567495110201092"), result.AuctionState.EraValidators[0].ValidatorWeights[4].Weight);
             
             Assert.AreEqual(3, result.AuctionState.Bids.Count);
-            Assert.AreEqual("01001b79b9a6e13d2b96e916f7fa7dff40496ba5188479263ca0fb2ccf8b714305", result.AuctionState.Bids[0].PublicKey.ToString().ToLower());
-            Assert.AreEqual(1, result.AuctionState.Bids[0].Delegators.Count);
-            Assert.AreEqual("018b34b15e023844531621cb52d42e216a2ea56034f0f40bf7cee566c32eae4f83", result.AuctionState.Bids[0].Delegators[0].DelegatorPublicKey.ToString().ToLower());
-            Assert.AreEqual(BigInteger.Parse("30268476029"), result.AuctionState.Bids[0].Delegators[0].StakedAmount);
-            Assert.IsNull(result.AuctionState.Bids[0].Delegators[0].VestingSchedule);
+            Assert.AreEqual("01001b79b9a6e13d2b96e916f7fa7dff40496ba5188479263ca0fb2ccf8b714305", result.AuctionState.Bids[0].Unified.PublicKey.ToString().ToLower());
+            Assert.AreEqual(1, result.AuctionState.Bids[0].Unified.Delegators.Count);
+            Assert.AreEqual("018b34b15e023844531621cb52d42e216a2ea56034f0f40bf7cee566c32eae4f83", result.AuctionState.Bids[0].Unified.Delegators[0].DelegatorPublicKey.ToString().ToLower());
+            Assert.AreEqual(BigInteger.Parse("30268476029"), result.AuctionState.Bids[0].Unified.Delegators[0].StakedAmount);
+            Assert.IsNull(result.AuctionState.Bids[0].Unified.Delegators[0].VestingSchedule);
         }
         
         [Test]
@@ -44,21 +44,32 @@ namespace NetCasperTest.RPCResponses
             var result = RpcResult.Parse<GetAuctionInfoResult>(json);
             Assert.IsNotNull(result);
             Assert.AreEqual("2.0.0", result.ApiVersion);
-            Assert.AreEqual("1e8f22fb799932c56ffcf4d48c014e09ba9b791a3280f9a8cc9c7614ce7d562e", result.AuctionState.StateRootHash);
-            Assert.AreEqual(1394, result.AuctionState.BlockHeight);
-            Assert.AreEqual(1394, result.AuctionState.BlockHeight);
+            Assert.AreEqual("c8228d6d6d45151766901ba3579461847a17db15a66ce9ef6ae2f3e3abffd132", result.AuctionState.StateRootHash);
+            Assert.AreEqual(3480973, result.AuctionState.BlockHeight);
             Assert.AreEqual(3, result.AuctionState.EraValidators.Count);
-            Assert.AreEqual(128, result.AuctionState.EraValidators[2].EraId);
-            Assert.AreEqual(5, result.AuctionState.EraValidators[2].ValidatorWeights.Count);
-            Assert.AreEqual("01fed662dc7f1f7af43ad785ba07a8cc05b7a96f9ee69613cfde43bc56bec1140b", result.AuctionState.EraValidators[2].ValidatorWeights[4].PublicKey.ToString().ToLower());
-            Assert.AreEqual(BigInteger.Parse("1366181433007372460"), result.AuctionState.EraValidators[2].ValidatorWeights[4].Weight);
+            Assert.AreEqual(14912, result.AuctionState.EraValidators[2].EraId);
+            Assert.AreEqual(4, result.AuctionState.EraValidators[2].ValidatorWeights.Count);
+            Assert.AreEqual("017536433a73f7562526f3e9fcb8d720428ae2d28788a9909f3c6f637a9d848a4b", result.AuctionState.EraValidators[2].ValidatorWeights[3].PublicKey.ToString().ToLower());
+            Assert.AreEqual(BigInteger.Parse("2030445261010189498"), result.AuctionState.EraValidators[2].ValidatorWeights[3].Weight);
             
-            Assert.AreEqual(5, result.AuctionState.Bids.Count);
-            Assert.AreEqual("01fed662dc7f1f7af43ad785ba07a8cc05b7a96f9ee69613cfde43bc56bec1140b", result.AuctionState.Bids[4].PublicKey.ToString().ToLower());
-            Assert.AreEqual(3, result.AuctionState.Bids[4].Delegators.Count);
-            Assert.AreEqual("0184f6d260f4ee6869ddb36affe15456de6ae045278fa2f467bb677561ce0dad55", result.AuctionState.Bids[4].Delegators[1].DelegatorPublicKey.ToString().ToLower());
-            Assert.AreEqual(BigInteger.Parse("654063155243124749"), result.AuctionState.Bids[4].Delegators[1].StakedAmount);
-            Assert.AreEqual(1719301233872, result.AuctionState.Bids[4].Delegators[1].VestingSchedule.InitialReleaseTimestampMillis);
+            Assert.AreEqual(4, result.AuctionState.Bids.Count);
+            
+            Assert.IsNotNull(result.AuctionState.Bids[0].Validator);
+            Assert.AreEqual("01358a7e107668ae2eb092dcfbeb97d2ec3cc8354d2a77bc8f232fff6630a826c3", result.AuctionState.Bids[0].Validator.PublicKey.ToString().ToLower());
+            Assert.AreEqual("uref-027d909fa0818f8b426b905795f608a6301168476b8013d7b3f682786796096f-007", result.AuctionState.Bids[0].Validator.BondingPurse.ToString());
+            Assert.AreEqual(500000000000, result.AuctionState.Bids[0].Validator.MinimumDelegationAmount);
+            Assert.AreEqual(1000000000000000000, result.AuctionState.Bids[0].Validator.MaximumDelegationAmount);
+            Assert.AreEqual(3, result.AuctionState.Bids[0].Validator.ReservedSlots);
+            Assert.AreEqual(1, result.AuctionState.Bids[0].Validator.DelegationRate);
+            Assert.AreEqual(BigInteger.Parse("2500000000"), result.AuctionState.Bids[0].Validator.StakedAmount);
+            Assert.AreEqual(true, result.AuctionState.Bids[0].Validator.Inactive);
+            
+            Assert.IsNotNull(result.AuctionState.Bids[3].Delegator);
+            Assert.AreEqual("01032146b0b9de01e26aaec7b0d1769920de94681dbd432c3530bfe591752ded6c", result.AuctionState.Bids[3].Delegator.ValidatorPublicKey.ToString().ToLower());
+            Assert.AreEqual("uref-d34ee21f5fe61feee2d9f15e0e369367aba62ba1b689e59c1e6ddc581ca99fdf-007", result.AuctionState.Bids[3].Delegator.BondingPurse.ToString());
+            Assert.AreEqual(BigInteger.Parse("1676515877735"), result.AuctionState.Bids[3].Delegator.StakedAmount);
+            Assert.IsNull(result.AuctionState.Bids[3].Delegator.DelegatorKind.PublicKey);
+            Assert.AreEqual("8af7b77811970792f98b806779dfc0d1a9fef5bad205c6be8bb884210d7d323c", result.AuctionState.Bids[3].Delegator.DelegatorKind.Purse);
         }
     }
 }

--- a/Casper.Network.SDK.Test/RPCResponses/GetAuctionInfoResultTest.cs
+++ b/Casper.Network.SDK.Test/RPCResponses/GetAuctionInfoResultTest.cs
@@ -27,12 +27,15 @@ namespace NetCasperTest.RPCResponses
             Assert.AreEqual("020377bc3ad54b5505971e001044ea822a3f6f307f8dc93fa45a05b7463c0a053bed", result.AuctionState.EraValidators[0].ValidatorWeights[4].PublicKey.ToString().ToLower());
             Assert.AreEqual(BigInteger.Parse("10567495110201092"), result.AuctionState.EraValidators[0].ValidatorWeights[4].Weight);
             
-            Assert.AreEqual(3, result.AuctionState.Bids.Count);
-            Assert.AreEqual("01001b79b9a6e13d2b96e916f7fa7dff40496ba5188479263ca0fb2ccf8b714305", result.AuctionState.Bids[0].Unified.PublicKey.ToString().ToLower());
-            Assert.AreEqual(1, result.AuctionState.Bids[0].Unified.Delegators.Count);
-            Assert.AreEqual("018b34b15e023844531621cb52d42e216a2ea56034f0f40bf7cee566c32eae4f83", result.AuctionState.Bids[0].Unified.Delegators[0].DelegatorPublicKey.ToString().ToLower());
-            Assert.AreEqual(BigInteger.Parse("30268476029"), result.AuctionState.Bids[0].Unified.Delegators[0].StakedAmount);
-            Assert.IsNull(result.AuctionState.Bids[0].Unified.Delegators[0].VestingSchedule);
+            Assert.AreEqual(6, result.AuctionState.Bids.Count);
+            Assert.AreEqual(3, result.AuctionState.Bids.Count(b => b.Validator != null));
+            Assert.AreEqual(3, result.AuctionState.Bids.Count(b => b.Delegator != null));
+            Assert.AreEqual("01001b79b9a6e13d2b96e916f7fa7dff40496ba5188479263ca0fb2ccf8b714305", result.AuctionState.Bids[4].Validator.PublicKey.ToString().ToLower());
+            Assert.AreEqual(BigInteger.Parse("908982507030"), result.AuctionState.Bids[4].Validator.StakedAmount);
+            Assert.AreEqual("01001b79b9a6e13d2b96e916f7fa7dff40496ba5188479263ca0fb2ccf8b714305", result.AuctionState.Bids[5].Delegator.ValidatorPublicKey.ToString().ToLower());
+            Assert.AreEqual("018b34b15e023844531621cb52d42e216a2ea56034f0f40bf7cee566c32eae4f83", result.AuctionState.Bids[5].Delegator.DelegatorKind.PublicKey.ToString().ToLower());
+            Assert.AreEqual(BigInteger.Parse("30268476029"), result.AuctionState.Bids[5].Delegator.StakedAmount);
+            Assert.AreEqual("uref-401f87167d733d8dd7d3efbf135a91ccd42fffb77b02d4a0075b963f14f1fbb4-007", result.AuctionState.Bids[5].Delegator.BondingPurse.ToString());
         }
         
         [Test]

--- a/Casper.Network.SDK.Test/TestData/get-auction-info-v200.json
+++ b/Casper.Network.SDK.Test/TestData/get-auction-info-v200.json
@@ -1,399 +1,132 @@
 {
   "api_version": "2.0.0",
   "auction_state": {
-    "state_root_hash": "1e8f22fb799932c56ffcf4d48c014e09ba9b791a3280f9a8cc9c7614ce7d562e",
-    "block_height": 1394,
+    "state_root_hash": "c8228d6d6d45151766901ba3579461847a17db15a66ce9ef6ae2f3e3abffd132",
+    "block_height": 3480973,
     "era_validators": [
       {
-        "era_id": 126,
+        "era_id": 14910,
         "validator_weights": [
           {
-            "public_key": "01509254f22690fbe7fb6134be574c4fbdb060dfa699964653b99753485e518ea6",
-            "weight": "773530002936061175"
+            "public_key": "01032146b0b9de01e26aaec7b0d1769920de94681dbd432c3530bfe591752ded6c",
+            "weight": "2030345838471710063"
           },
           {
-            "public_key": "0190664e16a17594ed2d0e3c279c4cf5894e8db0da15e3b91c938562a1caae32ab",
-            "weight": "2576240053903858104"
+            "public_key": "0126d4637eb0c0769274f03a696df1112383fa621c9f73f57af4c5c0fbadafa8cf",
+            "weight": "2030227732934792089"
           },
           {
-            "public_key": "01c867ff3cf1d4e4e68fc00922fdcb740304def196e223091dee62012f444b9eba",
-            "weight": "1391364929868444236"
+            "public_key": "0140afe8f752e5ff100e0189c080bc207e8805b3e5e82f792ec608de2f11f39f6c",
+            "weight": "2030338910449323803"
           },
           {
-            "public_key": "01f58b94526d280881f79744effebc555426190950d5dfdd2f8aaf10ceaec010c6",
-            "weight": "743423726792740916"
-          },
-          {
-            "public_key": "01fed662dc7f1f7af43ad785ba07a8cc05b7a96f9ee69613cfde43bc56bec1140b",
-            "weight": "1345521286498896079"
+            "public_key": "017536433a73f7562526f3e9fcb8d720428ae2d28788a9909f3c6f637a9d848a4b",
+            "weight": "2030266847164599460"
           }
         ]
       },
       {
-        "era_id": 127,
+        "era_id": 14911,
         "validator_weights": [
           {
-            "public_key": "01509254f22690fbe7fb6134be574c4fbdb060dfa699964653b99753485e518ea6",
-            "weight": "776022459374023984"
+            "public_key": "01032146b0b9de01e26aaec7b0d1769920de94681dbd432c3530bfe591752ded6c",
+            "weight": "2030438564141544419"
           },
           {
-            "public_key": "0190664e16a17594ed2d0e3c279c4cf5894e8db0da15e3b91c938562a1caae32ab",
-            "weight": "2596547825066264181"
+            "public_key": "0126d4637eb0c0769274f03a696df1112383fa621c9f73f57af4c5c0fbadafa8cf",
+            "weight": "2030321963971741685"
           },
           {
-            "public_key": "01c867ff3cf1d4e4e68fc00922fdcb740304def196e223091dee62012f444b9eba",
-            "weight": "1401840263593846706"
+            "public_key": "0140afe8f752e5ff100e0189c080bc207e8805b3e5e82f792ec608de2f11f39f6c",
+            "weight": "2030431133219240217"
           },
           {
-            "public_key": "01f58b94526d280881f79744effebc555426190950d5dfdd2f8aaf10ceaec010c6",
-            "weight": "751821266092616465"
-          },
-          {
-            "public_key": "01fed662dc7f1f7af43ad785ba07a8cc05b7a96f9ee69613cfde43bc56bec1140b",
-            "weight": "1358848185873249187"
+            "public_key": "017536433a73f7562526f3e9fcb8d720428ae2d28788a9909f3c6f637a9d848a4b",
+            "weight": "2030357058487126289"
           }
         ]
       },
       {
-        "era_id": 128,
+        "era_id": 14912,
         "validator_weights": [
           {
-            "public_key": "01509254f22690fbe7fb6134be574c4fbdb060dfa699964653b99753485e518ea6",
-            "weight": "778514256836908775"
+            "public_key": "01032146b0b9de01e26aaec7b0d1769920de94681dbd432c3530bfe591752ded6c",
+            "weight": "2030529783588751162"
           },
           {
-            "public_key": "0190664e16a17594ed2d0e3c279c4cf5894e8db0da15e3b91c938562a1caae32ab",
-            "weight": "2622847032216478396"
+            "public_key": "0126d4637eb0c0769274f03a696df1112383fa621c9f73f57af4c5c0fbadafa8cf",
+            "weight": "2030418207085001407"
           },
           {
-            "public_key": "01c867ff3cf1d4e4e68fc00922fdcb740304def196e223091dee62012f444b9eba",
-            "weight": "1412321239623424126"
+            "public_key": "0140afe8f752e5ff100e0189c080bc207e8805b3e5e82f792ec608de2f11f39f6c",
+            "weight": "2030524865448355568"
           },
           {
-            "public_key": "01f58b94526d280881f79744effebc555426190950d5dfdd2f8aaf10ceaec010c6",
-            "weight": "760216038315816781"
-          },
-          {
-            "public_key": "01fed662dc7f1f7af43ad785ba07a8cc05b7a96f9ee69613cfde43bc56bec1140b",
-            "weight": "1366181433007372460"
+            "public_key": "017536433a73f7562526f3e9fcb8d720428ae2d28788a9909f3c6f637a9d848a4b",
+            "weight": "2030445261010189498"
           }
         ]
       }
     ],
     "bids": [
       {
-        "public_key": "01509254f22690fbe7fb6134be574c4fbdb060dfa699964653b99753485e518ea6",
+        "public_key": "01358a7e107668ae2eb092dcfbeb97d2ec3cc8354d2a77bc8f232fff6630a826c3",
         "bid": {
-          "validator_public_key": "01509254f22690fbe7fb6134be574c4fbdb060dfa699964653b99753485e518ea6",
-          "bonding_purse": "uref-7141e0057da2902a50a7a0794f8941321e3f32c477f67621239e7964151e8734-007",
-          "staked_amount": "406303529637252506",
-          "delegation_rate": 1,
-          "vesting_schedule": {
-            "initial_release_timestamp_millis": 1719301233872,
-            "locked_amounts": [
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0"
-            ]
-          },
-          "delegators": [
-            {
-              "delegator_public_key": "018b46617b2b97e633b36530f2964b3f4c15916235910a2737e83d4fa2c7fad542",
-              "delegator": {
-                "delegator_public_key": "018b46617b2b97e633b36530f2964b3f4c15916235910a2737e83d4fa2c7fad542",
-                "staked_amount": "372210727199656269",
-                "bonding_purse": "uref-841b81b467c6bc114096446d0e121273645f21d91e1e33c0de3fc9398b294aac-007",
-                "validator_public_key": "01509254f22690fbe7fb6134be574c4fbdb060dfa699964653b99753485e518ea6",
-                "vesting_schedule": {
-                  "initial_release_timestamp_millis": 1719301233872,
-                  "locked_amounts": [
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0"
-                  ]
-                }
-              }
-            }
-          ],
-          "inactive": false
+          "Validator": {
+            "validator_public_key": "01358a7e107668ae2eb092dcfbeb97d2ec3cc8354d2a77bc8f232fff6630a826c3",
+            "bonding_purse": "uref-027d909fa0818f8b426b905795f608a6301168476b8013d7b3f682786796096f-007",
+              "staked_amount": "2500000000",
+            "delegation_rate": 1,
+            "vesting_schedule": null,
+            "inactive": true,
+            "minimum_delegation_amount": 500000000000,
+            "maximum_delegation_amount": 1000000000000000000,
+            "reserved_slots": 3
+          }
         }
       },
       {
-        "public_key": "0190664e16a17594ed2d0e3c279c4cf5894e8db0da15e3b91c938562a1caae32ab",
+        "public_key": "020234b6ebc6d9c826964a692951e4e7e0c1e7db2683ebbd4b9b209ad6ca5224f02c",
         "bid": {
-          "validator_public_key": "0190664e16a17594ed2d0e3c279c4cf5894e8db0da15e3b91c938562a1caae32ab",
-          "bonding_purse": "uref-d551374a39e56fb24bd5a3b3bf87a1ef7d4c08c6ce7892dcbb4a158ead9822c4-007",
-          "staked_amount": "1370640008489104648",
-          "delegation_rate": 1,
-          "vesting_schedule": {
-            "initial_release_timestamp_millis": 1719301233872,
-            "locked_amounts": [
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0"
-            ]
-          },
-          "delegators": [
-            {
-              "delegator_public_key": "0197b79d1a1351f8fb922b9f7f556d2bbfdba5105df9eaa6caa07804c703a641ed",
-              "delegator": {
-                "delegator_public_key": "0197b79d1a1351f8fb922b9f7f556d2bbfdba5105df9eaa6caa07804c703a641ed",
-                "staked_amount": "1252207023727373748",
-                "bonding_purse": "uref-cf1c24cc7b54a82ef379dcc87a3958ef0ffadf817a605b1e425d3a659946350b-007",
-                "validator_public_key": "0190664e16a17594ed2d0e3c279c4cf5894e8db0da15e3b91c938562a1caae32ab",
-                "vesting_schedule": {
-                  "initial_release_timestamp_millis": 1719301233872,
-                  "locked_amounts": [
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0"
-                  ]
-                }
-              }
-            }
-          ],
-          "inactive": false
+          "Validator": {
+            "validator_public_key": "020234b6ebc6d9c826964a692951e4e7e0c1e7db2683ebbd4b9b209ad6ca5224f02c",
+            "bonding_purse": "uref-4a15ba727136c9cb324af202412f3a2cb0d53cd58913647c6e34336f80758f54-007",
+            "staked_amount": "1000000000",
+            "delegation_rate": 1,
+            "vesting_schedule": null,
+            "inactive": true,
+            "minimum_delegation_amount": 500000000000,
+            "maximum_delegation_amount": 1000000000000000000,
+            "reserved_slots": 0
+          }
         }
       },
       {
-        "public_key": "01c867ff3cf1d4e4e68fc00922fdcb740304def196e223091dee62012f444b9eba",
+        "public_key": "01032146b0b9de01e26aaec7b0d1769920de94681dbd432c3530bfe591752ded6c",
         "bid": {
-          "validator_public_key": "01c867ff3cf1d4e4e68fc00922fdcb740304def196e223091dee62012f444b9eba",
-          "bonding_purse": "uref-5af966267c401835bc3535c8517353eeed45c4e33cac29b50a4bb21d5a137305-007",
-          "staked_amount": "737000667377542259",
-          "delegation_rate": 1,
-          "vesting_schedule": {
-            "initial_release_timestamp_millis": 1719301233872,
-            "locked_amounts": [
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0"
-            ]
-          },
-          "delegators": [
-            {
-              "delegator_public_key": "01a5a5b7328118681638be3e06c8749609280dba4c9daf9aeb3d3464b8839b018a",
-              "delegator": {
-                "delegator_public_key": "01a5a5b7328118681638be3e06c8749609280dba4c9daf9aeb3d3464b8839b018a",
-                "staked_amount": "675320572245881867",
-                "bonding_purse": "uref-b22d651969ee70cd17d188f84dbdb6e12e0d8781c6f6615887ddd2ca4164dd7f-007",
-                "validator_public_key": "01c867ff3cf1d4e4e68fc00922fdcb740304def196e223091dee62012f444b9eba",
-                "vesting_schedule": {
-                  "initial_release_timestamp_millis": 1719301233872,
-                  "locked_amounts": [
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0"
-                  ]
-                }
-              }
-            }
-          ],
-          "inactive": false
-        }
-      },
-      {
-        "public_key": "01f58b94526d280881f79744effebc555426190950d5dfdd2f8aaf10ceaec010c6",
-        "bid": {
-          "validator_public_key": "01f58b94526d280881f79744effebc555426190950d5dfdd2f8aaf10ceaec010c6",
-          "bonding_purse": "uref-ae3f94140d484ffdb28cf447e05edc64df13ca29adc33acca948fa73226b951b-007",
-          "staked_amount": "395603338820466037",
-          "delegation_rate": 1,
-          "vesting_schedule": {
-            "initial_release_timestamp_millis": 1719301233872,
-            "locked_amounts": [
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0"
-            ]
-          },
-          "delegators": [
-            {
-              "delegator_public_key": "0106ed45915392c02b37136618372ac8dde8e0e3b8ee6190b2ca6db539b354ede4",
-              "delegator": {
-                "delegator_public_key": "0106ed45915392c02b37136618372ac8dde8e0e3b8ee6190b2ca6db539b354ede4",
-                "staked_amount": "364612699495350744",
-                "bonding_purse": "uref-3ca8c2afabe6120c722f260f53b3dd406178b5341760618ed98f826d9d9aac3d-007",
-                "validator_public_key": "01f58b94526d280881f79744effebc555426190950d5dfdd2f8aaf10ceaec010c6",
-                "vesting_schedule": {
-                  "initial_release_timestamp_millis": 1719301233872,
-                  "locked_amounts": [
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0"
-                  ]
-                }
-              }
-            }
-          ],
-          "inactive": false
-        }
-      },
-      {
-        "public_key": "01fed662dc7f1f7af43ad785ba07a8cc05b7a96f9ee69613cfde43bc56bec1140b",
-        "bid": {
-          "validator_public_key": "01fed662dc7f1f7af43ad785ba07a8cc05b7a96f9ee69613cfde43bc56bec1140b",
-          "bonding_purse": "uref-5c654b8a6f9d0130770c37e6dddca477d02424d718aed53d0315f163c2591180-007",
-          "staked_amount": "712016868136394248",
-          "delegation_rate": 1,
-          "vesting_schedule": {
-            "initial_release_timestamp_millis": 1719301233872,
-            "locked_amounts": [
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0",
-              "0"
-            ]
-          },
-          "delegators": [
-            {
-              "delegator_public_key": "0106ed45915392c02b37136618372ac8dde8e0e3b8ee6190b2ca6db539b354ede4",
-              "delegator": {
-                "delegator_public_key": "0106ed45915392c02b37136618372ac8dde8e0e3b8ee6190b2ca6db539b354ede4",
-                "staked_amount": "49664621804232",
-                "bonding_purse": "uref-9120257acebbf71672c3397a08b18374dd995e7e176c7faf9fd0646c2d5a0cdf-007",
-                "validator_public_key": "01fed662dc7f1f7af43ad785ba07a8cc05b7a96f9ee69613cfde43bc56bec1140b",
-                "vesting_schedule": null
-              }
+          "Delegator": {
+            "delegator_kind": {
+              "Purse": "1cd4fc41e3f750e52024f54b1ac3a757027baad64d47ffb6d4e968967618740b"
             },
-            {
-              "delegator_public_key": "0184f6d260f4ee6869ddb36affe15456de6ae045278fa2f467bb677561ce0dad55",
-              "delegator": {
-                "delegator_public_key": "0184f6d260f4ee6869ddb36affe15456de6ae045278fa2f467bb677561ce0dad55",
-                "staked_amount": "654063155243124749",
-                "bonding_purse": "uref-64d20811fbd63205cb2267c01b2531198fbeeec69cf1c2611664553cc44bb621-007",
-                "validator_public_key": "01fed662dc7f1f7af43ad785ba07a8cc05b7a96f9ee69613cfde43bc56bec1140b",
-                "vesting_schedule": {
-                  "initial_release_timestamp_millis": 1719301233872,
-                  "locked_amounts": [
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0",
-                    "0"
-                  ]
-                }
-              }
+            "staked_amount": "6435861748906",
+            "bonding_purse": "uref-30c3f9163e14b9b00c967daaecdba61d9a7a25f454b9f23d556200e1ab847955-007",
+            "validator_public_key": "01032146b0b9de01e26aaec7b0d1769920de94681dbd432c3530bfe591752ded6c",
+            "vesting_schedule": null
+          }
+        }
+      },
+      {
+        "public_key": "01032146b0b9de01e26aaec7b0d1769920de94681dbd432c3530bfe591752ded6c",
+        "bid": {
+          "Delegator": {
+            "delegator_kind": {
+              "Purse": "8af7b77811970792f98b806779dfc0d1a9fef5bad205c6be8bb884210d7d323c"
             },
-            {
-              "delegator_public_key": "018b46617b2b97e633b36530f2964b3f4c15916235910a2737e83d4fa2c7fad542",
-              "delegator": {
-                "delegator_public_key": "018b46617b2b97e633b36530f2964b3f4c15916235910a2737e83d4fa2c7fad542",
-                "staked_amount": "51745006049231",
-                "bonding_purse": "uref-a5e8d8ad4ad983dd01270dcf1c7d3d2112ab48b55e2a0347fbbb51066fd686fc-007",
-                "validator_public_key": "01fed662dc7f1f7af43ad785ba07a8cc05b7a96f9ee69613cfde43bc56bec1140b",
-                "vesting_schedule": null
-              }
-            }
-          ],
-          "inactive": false
+            "staked_amount": "1676515877735",
+            "bonding_purse": "uref-d34ee21f5fe61feee2d9f15e0e369367aba62ba1b689e59c1e6ddc581ca99fdf-007",
+            "validator_public_key": "01032146b0b9de01e26aaec7b0d1769920de94681dbd432c3530bfe591752ded6c",
+            "vesting_schedule": null
+          }
         }
       }
     ]

--- a/Casper.Network.SDK/Converters/NamedArgsListConverter.cs
+++ b/Casper.Network.SDK/Converters/NamedArgsListConverter.cs
@@ -21,16 +21,22 @@ namespace Casper.Network.SDK.Converters
             reader.Read();
             if (named != "Named")
                 throw new JsonException("Named property expected");
-            
+
             reader.Read(); // Start array
 
             List<T> list = new List<T>();
 
-            if (reader.TokenType == JsonTokenType.EndObject ||
-                reader.TokenType == JsonTokenType.EndArray)
+            if (reader.TokenType == JsonTokenType.EndObject)
                 return list; //this is an empty list, just return...
 
-            var tConverter = Activator.CreateInstance(typeof(TConverter)) as JsonConverter;
+            if (reader.TokenType == JsonTokenType.EndArray)
+            {
+                //this is an empty list, skip end array item and return...
+                reader.Read();
+                return list;
+            }
+
+        var tConverter = Activator.CreateInstance(typeof(TConverter)) as JsonConverter;
 
             if (reader.TokenType is JsonTokenType.StartArray or JsonTokenType.StartObject or JsonTokenType.PropertyName)
             {

--- a/Casper.Network.SDK/JsonRpc/CasperMethods.cs
+++ b/Casper.Network.SDK/JsonRpc/CasperMethods.cs
@@ -61,6 +61,25 @@ namespace Casper.Network.SDK.JsonRpc
         {
         }
     }
+    
+    public class GetAuctionInfoV2 : RpcMethod
+    {
+        /// <summary>
+        /// Returns the bids and validators at a given block.
+        /// </summary>
+        /// <param name="blockHash">Block hash for which the auction info is queried. Null for the most recent auction info.</param>
+        public GetAuctionInfoV2(string blockHash) : base("state_get_auction_info_v2", blockHash)
+        {
+        }
+
+        /// <summary>
+        /// Returns the bids and validators at a given block.
+        /// </summary>
+        /// <param name="height">Block height for which the auction info is queried.</param>
+        public GetAuctionInfoV2(ulong height) : base("state_get_auction_info_v2", height)
+        {
+        }
+    }
 
     public class GetAccountInfo : RpcMethod
     {

--- a/Casper.Network.SDK/NetCasperClient.cs
+++ b/Casper.Network.SDK/NetCasperClient.cs
@@ -134,16 +134,21 @@ namespace Casper.Network.SDK
         /// <param name="blockHeight">Block height for which the auction info is queried.</param>
         public async Task<RpcResponse<GetAuctionInfoResult>> GetAuctionInfo(ulong blockHeight)
         {
-            if (await GetNodeVersion() == 2)
+            var nodeVersion = await GetNodeVersion();
+            RpcMethod method = null;
+            
+            if (nodeVersion == 1)
+                method = new GetAuctionInfo(blockHeight);
+            else 
             {
-                var method = new GetAuctionInfoV2(blockHeight);
-                return await SendRpcRequestAsync<GetAuctionInfoResult>(method);
+                var getBlockResponse = await GetBlock(blockHeight);
+                if (getBlockResponse.Parse().Block.Version == 2)
+                    method = new GetAuctionInfoV2(blockHeight);
+                else
+                    method = new GetAuctionInfo(blockHeight);
             }
-            else
-            {
-                var method = new GetAuctionInfo(blockHeight);
-                return await SendRpcRequestAsync<GetAuctionInfoResult>(method);                
-            }
+            
+            return await SendRpcRequestAsync<GetAuctionInfoResult>(method);   
         }
 
         /// <summary>

--- a/Casper.Network.SDK/Types/AuctionState.cs
+++ b/Casper.Network.SDK/Types/AuctionState.cs
@@ -13,9 +13,9 @@ namespace Casper.Network.SDK.Types
         /// All bids contained within a vector.
         /// </summary>
         [JsonPropertyName("bids")]
-        [JsonConverter(typeof(BidsListConverter))]
-        public List<Bid> Bids { get; init; }
-
+        [JsonConverter(typeof(BidKindsListConverter))]
+        public List<BidKind> Bids { get; init; }
+        
         /// <summary>
         /// Block height.
         /// </summary>


### PR DESCRIPTION
### Summary

GetAuctionInfo() method now calls `state_get_auction_info_v2` when the RPC client is pointing to a Casper 2.0 network.

### TODO

### Checklist

- [X] Code is properly formatted
- [X] All commits are signed
- [X] Tests included/updated or not needed
- [X] Documentation (manuals or wiki) has been updated or is not required


