### PR TITLE
Bugfix: disabled versions deserialization

### DIFF
--- a/Casper.Network.SDK.Test/RPCResponses/GetPackageResultTest.cs
+++ b/Casper.Network.SDK.Test/RPCResponses/GetPackageResultTest.cs
@@ -19,9 +19,11 @@ namespace NetCasperTest.RPCResponses
             Assert.IsNotNull(result.ContractPackage);
             Assert.IsNull(result.Package);
             Assert.AreEqual("uref-6fc684fea74b278cbb18b546a6d9242b810ce58a2ff05d17493b19aa08f540e0-007", result.ContractPackage.AccessKey.ToString());
-            Assert.AreEqual(1, result.ContractPackage.Versions.Count);
+            Assert.AreEqual(2, result.ContractPackage.Versions.Count);
             Assert.AreEqual(2, result.ContractPackage.Versions[0].ProtocolVersionMajor);
             Assert.AreEqual(1, result.ContractPackage.Versions[0].Version);
+            Assert.AreEqual(2, result.ContractPackage.DisabledVersions[0].ProtocolVersionMajor);
+            Assert.AreEqual(4, result.ContractPackage.DisabledVersions[0].Version);
             Assert.AreEqual("contract-25aa2d3cc62a302746c08ae885454d6e8a9c8609aaa7468b24284e5d29c5d2f1", result.ContractPackage.Versions[0].Hash);
             Assert.AreEqual(LockStatus.Unlocked, result.ContractPackage.LockStatus);
         }

--- a/Casper.Network.SDK.Test/TestData/get-package-result-contract-package-v200.json
+++ b/Casper.Network.SDK.Test/TestData/get-package-result-contract-package-v200.json
@@ -8,9 +8,16 @@
           "protocol_version_major": 2,
           "contract_version": 1,
           "contract_hash": "contract-25aa2d3cc62a302746c08ae885454d6e8a9c8609aaa7468b24284e5d29c5d2f1"
+        },
+        {
+          "protocol_version_major": 2,
+          "contract_version": 4,
+          "contract_hash": "contract-2222222222222222222222222222222222222222222222222222222222222222"
         }
       ],
-      "disabled_versions": [],
+      "disabled_versions": [
+        [2,4]
+      ],
       "groups": [],
       "lock_status": "Unlocked"
     }

--- a/Casper.Network.SDK/Types/ContractPackage.cs
+++ b/Casper.Network.SDK/Types/ContractPackage.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Casper.Network.SDK.Converters;
 
@@ -7,6 +9,7 @@ namespace Casper.Network.SDK.Types
     /// <summary>
     /// A disabled version of a contract.
     /// </summary>
+    [JsonConverter(typeof(DisabledVersion.DisabledVersionConverter))]
     public class DisabledVersion
     {
         /// <summary>
@@ -14,11 +17,68 @@ namespace Casper.Network.SDK.Types
         /// </summary>
         [JsonPropertyName("contract_version")]
         public uint Version { get; init; }
-        
+
         [JsonPropertyName("protocol_version_major")]
         public uint ProtocolVersionMajor { get; init; }
+
+        public class DisabledVersionConverter : JsonConverter<DisabledVersion>
+        {
+            public override DisabledVersion Read
+            (
+                ref Utf8JsonReader reader,
+                Type typeToConvert,
+                JsonSerializerOptions options
+            )
+            {
+                if (reader.TokenType == JsonTokenType.StartObject)
+                {
+                    using (JsonDocument doc = JsonDocument.ParseValue(ref reader))
+                    {
+                        doc.RootElement.TryGetProperty("protocol_version_major", out var protocolVersionMajor);
+                        doc.RootElement.TryGetProperty("contract_version", out var contractVersion);
+                        if (!protocolVersionMajor.ValueKind.Equals(JsonValueKind.Number) ||
+                            !contractVersion.ValueKind.Equals(JsonValueKind.Number))
+                            throw new JsonException("Cannot deserialize StoredValue. Number expected for protocol_version_major and contract_version.");
+                        return new DisabledVersion()
+                        {
+                            ProtocolVersionMajor = protocolVersionMajor.GetUInt32(),
+                            Version = contractVersion.GetUInt32()
+                        };
+                    }
+                }
+
+                if (reader.TokenType != JsonTokenType.StartArray)
+                    throw new JsonException("Cannot deserialize StoredValue. StartObject expected.");
+                {
+                    using (JsonDocument doc = JsonDocument.ParseValue(ref reader))
+                    {
+                        var versionsArray = JsonSerializer.Deserialize<List<uint>>(doc.RootElement.GetRawText());
+
+                        if (versionsArray?.Count != 2)
+                            throw new JsonException(
+                                "Cannot deserialize StoredValue. Array of length 2 expected for disabled_version item.");
+
+                        return new DisabledVersion()
+                        {
+                            ProtocolVersionMajor = versionsArray[0],
+                            Version = versionsArray[1]
+                        };
+                    }
+                }
+
+            }
+
+
+            public override void Write(
+                Utf8JsonWriter writer,
+                DisabledVersion value,
+                JsonSerializerOptions options)
+            {
+                throw new NotImplementedException("Write method for DisabledVersion not yet implemented");
+            }
+        }
     }
-    
+
     /// <summary>
     /// Information related to an active version of a contract.
     /// </summary>
@@ -29,13 +89,13 @@ namespace Casper.Network.SDK.Types
         /// </summary>
         [JsonPropertyName("contract_hash")]
         public string Hash { get; init; }
-        
+
         /// <summary>
         /// Contract version.
         /// </summary>
         [JsonPropertyName("contract_version")]
         public uint Version { get; init; }
-        
+
         [JsonPropertyName("protocol_version_major")]
         public uint ProtocolVersionMajor { get; init; }
     }
@@ -50,7 +110,7 @@ namespace Casper.Network.SDK.Types
         /// </summary>
         [JsonPropertyName("group")]
         public string Label { get; init; }
-        
+
         /// <summary>
         /// List of URefs associated with the group label.
         /// </summary>
@@ -67,7 +127,7 @@ namespace Casper.Network.SDK.Types
         Locked,
         Unlocked,
     }
-    
+
     /// <summary>
     /// Contract definition, metadata, and security container.
     /// </summary>
@@ -76,13 +136,13 @@ namespace Casper.Network.SDK.Types
         [JsonPropertyName("access_key")]
         [JsonConverter(typeof(GlobalStateKey.GlobalStateKeyConverter))]
         public URef AccessKey { get; init; }
-        
+
         /// <summary>
         /// List of disabled versions of a contract.
         /// </summary>
         [JsonPropertyName("disabled_versions")]
         public List<DisabledVersion> DisabledVersions { get; init; }
-        
+
         /// <summary>
         /// Groups associate a set of URefs with a label. Entry points on a contract can be given
         /// a list of labels they accept and the runtime will check that a URef from at least one
@@ -90,17 +150,17 @@ namespace Casper.Network.SDK.Types
         /// </summary>
         [JsonPropertyName("groups")]
         public List<Group> Groups { get; init; }
-        
+
         /// <summary>
         /// List of active versions of a contract.
         /// </summary>
         [JsonPropertyName("versions")]
         public List<ContractVersion> Versions { get; init; }
-        
+
         /// <summary>
         /// The current state of the contract package.
         /// </summary>
-        [JsonPropertyName("lock_status")] 
+        [JsonPropertyName("lock_status")]
         [JsonConverter(typeof(JsonStringEnumConverter))]
         public LockStatus LockStatus { get; init; }
     }


### PR DESCRIPTION
### Summary

disabled_versions in the ContractPacket type has a different structure in Casper 2. This PR fixes deserialization for Casper 2.

### TODO


### Checklist

- [X] Code is properly formatted
- [X] All commits are signed
- [X] Tests included/updated or not needed
- [X] Documentation (manuals or wiki) has been updated or is not required


