### PR TITLE
Refund and Current Gas Price fields parsing

### DIFF
--- a/Casper.Network.SDK.Test/RPCResponses/GetTransactionTest.cs
+++ b/Casper.Network.SDK.Test/RPCResponses/GetTransactionTest.cs
@@ -2,6 +2,7 @@ using System.IO;
 using Casper.Network.SDK.JsonRpc.ResultTypes;
 using Casper.Network.SDK.Types;
 using NUnit.Framework;
+using Org.BouncyCastle.Math;
 using Org.BouncyCastle.Utilities.Encoders;
 
 namespace NetCasperTest.RPCResponses
@@ -36,6 +37,8 @@ namespace NetCasperTest.RPCResponses
             AssertExtensions.IsHash(result.ExecutionInfo.BlockHash);
             Assert.IsTrue(result.ExecutionInfo.BlockHeight > 0);
             Assert.IsNotNull(result.ExecutionInfo.ExecutionResult);
+            Assert.AreEqual(1, result.ExecutionInfo.ExecutionResult.CurrentGasPrice);
+            Assert.AreEqual("30000", result.ExecutionInfo.ExecutionResult.Refund.ToString());
         }
         
         [Test]
@@ -136,6 +139,8 @@ namespace NetCasperTest.RPCResponses
             AssertExtensions.IsHash(result.ExecutionInfo.BlockHash);
             Assert.IsTrue(result.ExecutionInfo.BlockHeight > 0);
             Assert.IsNotNull(result.ExecutionInfo.ExecutionResult);
+            Assert.AreEqual(2, result.ExecutionInfo.ExecutionResult.CurrentGasPrice);
+            Assert.AreEqual("2123123123", result.ExecutionInfo.ExecutionResult.Refund.ToString());
         }
         
         [Test]

--- a/Casper.Network.SDK.Test/TestData/get-transaction-deploy-v200.json
+++ b/Casper.Network.SDK.Test/TestData/get-transaction-deploy-v200.json
@@ -81,6 +81,8 @@
         "limit": "10000",
         "consumed": "10000",
         "cost": "10000",
+        "refund": "30000",
+        "current_price": 1,
         "payment": [],
         "transfers": [
           {

--- a/Casper.Network.SDK.Test/TestData/get-transaction-stored-v200.json
+++ b/Casper.Network.SDK.Test/TestData/get-transaction-stored-v200.json
@@ -75,6 +75,8 @@
         "limit": "3000000000",
         "consumed": "1241925",
         "cost": "3000000000",
+        "refund": "2123123123",
+        "current_price": 2,
         "transfers": [],
         "size_estimate": 591,
         "effects": [

--- a/Casper.Network.SDK/Types/ExecutionResult.cs
+++ b/Casper.Network.SDK/Types/ExecutionResult.cs
@@ -53,6 +53,8 @@ namespace Casper.Network.SDK.Types
                 ErrorMessage = executionResult.ErrorMessage,
                 // Transfers = executionResult.Transfers,
                 Cost = executionResult.Cost,
+                Refund = 0,
+                CurrentGasPrice = 1,
                 Limit = 0,
                 Consumed = 0,
                 Effect = v2Effect,
@@ -81,6 +83,19 @@ namespace Casper.Network.SDK.Types
         [JsonPropertyName("cost")]
         [JsonConverter(typeof(BigIntegerConverter))]
         public BigInteger Cost { get; init; }
+                
+        /// <summary>
+        /// How much was refunded (if any)
+        /// </summary>
+        [JsonPropertyName("refund")]
+        [JsonConverter(typeof(BigIntegerConverter))]
+        public BigInteger Refund { get; init; }
+        
+        /// <summary>
+        /// The gas price of the era.
+        /// </summary>
+        [JsonPropertyName("current_price")]
+        public UInt16 CurrentGasPrice { get; init; }
         
         /// <summary>
         /// If there is no error message, this execution was processed successfully. If there is an error message, this
@@ -150,6 +165,8 @@ namespace Casper.Network.SDK.Types
                                 ErrorMessage = erv2.ErrorMessage,
                                 Transfers = erv2.Transfers,
                                 Cost = erv2.Cost,
+                                Refund = erv2.Refund,
+                                CurrentGasPrice = erv2.CurrentGasPrice,
                                 Limit = erv2.Limit,
                                 Consumed = erv2.Consumed,
                                 Effect = erv2.Effect,
@@ -342,6 +359,19 @@ namespace Casper.Network.SDK.Types
         [JsonConverter(typeof(BigIntegerConverter))]
         public BigInteger Cost { get; init; }
         
+        /// <summary>
+        /// How much was refunded (if any)
+        /// </summary>
+        [JsonPropertyName("refund")]
+        [JsonConverter(typeof(BigIntegerConverter))]
+        public BigInteger Refund { get; init; }
+        
+        /// <summary>
+        /// The gas price of the era.
+        /// </summary>
+        [JsonPropertyName("current_price")]
+        public UInt16 CurrentGasPrice { get; init; }
+
         /// <summary>
         /// If there is no error message, this execution was processed successfully. If there is an error message, this
         /// execution failed to fully process for the stated reason.


### PR DESCRIPTION
### Summary

`refund` and `current_price` fields have been added to the `ExecutionResult` object in a `GetDeploy` and `GetTransaction` responses. This PR handles parsing of these two new fields.

### TODO

### Checklist

- [X] Code is properly formatted
- [X] All commits are signed
- [X] Tests included/updated or not needed
- [X] Documentation (manuals or wiki) has been updated or is not required


