### PR TITLE
[Bugfix] Handle message keys contract prefixes

### DIFF
--- a/Casper.Network.SDK.Test/GlobalStateKeyTest.cs
+++ b/Casper.Network.SDK.Test/GlobalStateKeyTest.cs
@@ -541,7 +541,7 @@ namespace NetCasperTest
         {
             var hashAddr = "55d4a6915291da12afded37fa5bc01f0803a2f0faf6acb7ec4c7ca6ab76f3330";
             var topicStr = "5721a6d9d7a9afe5dfdb35276fb823bed0f825350e4d865a5ec0110c380de4e1";
-            var msgKeyStr = $"message-topic-{hashAddr}-{topicStr}";
+            var msgKeyStr = $"message-topic-entity-contract-{hashAddr}-{topicStr}";
         
             var key = GlobalStateKey.FromString(msgKeyStr);
             Assert.IsNotNull(key);
@@ -562,8 +562,8 @@ namespace NetCasperTest
         {
             var hashAddr = "55d4a6915291da12afded37fa5bc01f0803a2f0faf6acb7ec4c7ca6ab76f3330";
             var topicStr = "5721a6d9d7a9afe5dfdb35276fb823bed0f825350e4d865a5ec0110c380de4e1";
-            var indexStr = "f";
-            var msgKeyStr = $"message-{hashAddr}-{topicStr}-{indexStr}";
+            var indexStr = "0f";
+            var msgKeyStr = $"message-entity-contract-{hashAddr}-{topicStr}-{indexStr}";
         
             var key = GlobalStateKey.FromString(msgKeyStr);
             Assert.IsNotNull(key);

--- a/Casper.Network.SDK.Test/GlobalStateKeyTest.cs
+++ b/Casper.Network.SDK.Test/GlobalStateKeyTest.cs
@@ -539,9 +539,9 @@ namespace NetCasperTest
         [Test]
         public void MessageTopicKeyTest()
         {
-            var hashAddr = "55d4a6915291da12afded37fa5bc01f0803a2f0faf6acb7ec4c7ca6ab76f3330";
+            var hashAddr = "entity-contract-55d4a6915291da12afded37fa5bc01f0803a2f0faf6acb7ec4c7ca6ab76f3330";
             var topicStr = "5721a6d9d7a9afe5dfdb35276fb823bed0f825350e4d865a5ec0110c380de4e1";
-            var msgKeyStr = $"message-topic-entity-contract-{hashAddr}-{topicStr}";
+            var msgKeyStr = $"message-topic-{hashAddr}-{topicStr}";
         
             var key = GlobalStateKey.FromString(msgKeyStr);
             Assert.IsNotNull(key);
@@ -549,8 +549,8 @@ namespace NetCasperTest
 
             var messageKey = key as MessageKey;
             Assert.IsNotNull(messageKey);
-            Assert.IsNotNull(messageKey.HashAddr);
-            Assert.AreEqual(hashAddr, messageKey.HashAddr);
+            Assert.IsNotNull(messageKey.AddressableEntity);
+            Assert.AreEqual(hashAddr, messageKey.AddressableEntity.ToString());
             Assert.AreEqual(topicStr, messageKey.TopicHash);
             Assert.IsFalse(messageKey.Index.HasValue);
             Assert.AreEqual(msgKeyStr, messageKey.ToString().ToLower());
@@ -560,10 +560,10 @@ namespace NetCasperTest
         [Test]
         public void MessageIndexKeyTest()
         {
-            var hashAddr = "55d4a6915291da12afded37fa5bc01f0803a2f0faf6acb7ec4c7ca6ab76f3330";
+            var hashAddr = "entity-contract-55d4a6915291da12afded37fa5bc01f0803a2f0faf6acb7ec4c7ca6ab76f3330";
             var topicStr = "5721a6d9d7a9afe5dfdb35276fb823bed0f825350e4d865a5ec0110c380de4e1";
             var indexStr = "0f";
-            var msgKeyStr = $"message-entity-contract-{hashAddr}-{topicStr}-{indexStr}";
+            var msgKeyStr = $"message-{hashAddr}-{topicStr}-{indexStr}";
         
             var key = GlobalStateKey.FromString(msgKeyStr);
             Assert.IsNotNull(key);
@@ -571,8 +571,8 @@ namespace NetCasperTest
 
             var messageKey = key as MessageKey;
             Assert.IsNotNull(messageKey);
-            Assert.IsNotNull(messageKey.HashAddr);
-            Assert.AreEqual(hashAddr, messageKey.HashAddr);
+            Assert.IsNotNull(messageKey.AddressableEntity);
+            Assert.AreEqual(hashAddr, messageKey.AddressableEntity.ToString());
             Assert.AreEqual(topicStr, messageKey.TopicHash);
             Assert.IsTrue(messageKey.Index.HasValue);
             Assert.AreEqual(15, messageKey.Index.Value);

--- a/Casper.Network.SDK.Test/RPCResponses/GetPackageResultTest.cs
+++ b/Casper.Network.SDK.Test/RPCResponses/GetPackageResultTest.cs
@@ -26,6 +26,9 @@ namespace NetCasperTest.RPCResponses
             Assert.AreEqual(4, result.ContractPackage.DisabledVersions[0].Version);
             Assert.AreEqual("contract-25aa2d3cc62a302746c08ae885454d6e8a9c8609aaa7468b24284e5d29c5d2f1", result.ContractPackage.Versions[0].Hash);
             Assert.AreEqual(LockStatus.Unlocked, result.ContractPackage.LockStatus);
+            
+            var package = Package.FromContractPackage(result.ContractPackage);
+            Assert.AreEqual("entity-contract-25aa2d3cc62a302746c08ae885454d6e8a9c8609aaa7468b24284e5d29c5d2f1", package.Versions[0].AddressableEntity.ToString());
         }
         [Test]
         public void GetPackageResultPackageTest_v200()
@@ -41,7 +44,8 @@ namespace NetCasperTest.RPCResponses
             Assert.AreEqual(1, result.Package.Versions.Count);
             Assert.AreEqual(2, result.Package.Versions[0].EntityVersion.ProtocolVersionMajor);
             Assert.AreEqual(1, result.Package.Versions[0].EntityVersion.Version);
-            Assert.AreEqual("addressable-entity-e51af99d88fd26a282de00271c49a6c256232b344aa7907d2c8603b2bd5217c9", result.Package.Versions[0].AddressableEntityHash);
+            Assert.AreEqual("entity-contract-e51af99d88fd26a282de00271c49a6c256232b344aa7907d2c8603b2bd5217c9", result.Package.Versions[0].AddressableEntity.ToString());
+            Assert.AreEqual(EntityKindEnum.Contract, result.Package.Versions[0].AddressableEntity.Kind);
             Assert.AreEqual(LockStatus.Unlocked, result.Package.LockStatus);
         }
     }

--- a/Casper.Network.SDK.Test/TestData/get-package-result-package-v200.json
+++ b/Casper.Network.SDK.Test/TestData/get-package-result-package-v200.json
@@ -8,7 +8,7 @@
             "protocol_version_major": 2,
             "entity_version": 1
           },
-          "addressable_entity_hash": "addressable-entity-e51af99d88fd26a282de00271c49a6c256232b344aa7907d2c8603b2bd5217c9"
+          "entity_addr": "entity-contract-e51af99d88fd26a282de00271c49a6c256232b344aa7907d2c8603b2bd5217c9"
         }
       ],
       "disabled_versions": [],

--- a/Casper.Network.SDK/Types/GlobalStateKey/MessageKey.cs
+++ b/Casper.Network.SDK/Types/GlobalStateKey/MessageKey.cs
@@ -27,6 +27,9 @@ namespace Casper.Network.SDK.Types
             if (key.StartsWith(TOPIC_PREFIX))
             {
                 key = key.Substring(TOPIC_PREFIX.Length);
+                key = key.Replace("entity-contract-", "");
+                key = key.Replace("entity-system-", "");
+                key = key.Replace("entity-account-", "");
                 var parts = key.Split('-');
                 if(parts.Length == 2)
                 {
@@ -38,6 +41,9 @@ namespace Casper.Network.SDK.Types
             }
             else
             {
+                key = key.Replace("entity-contract-", "");
+                key = key.Replace("entity-system-", "");
+                key = key.Replace("entity-account-", "");
                 var parts = key.Split('-');
                 if (parts.Length == 3)
                 {

--- a/Casper.Network.SDK/Types/GlobalStateKey/MessageKey.cs
+++ b/Casper.Network.SDK/Types/GlobalStateKey/MessageKey.cs
@@ -10,8 +10,8 @@ namespace Casper.Network.SDK.Types
         private const string KEY_PREFIX = "message-";
         private const string TOPIC_PREFIX = "topic-";
         
-        public string HashAddr { get; init; }
-        
+        public AddressableEntityKey AddressableEntity { get; init; }
+
         public string TopicHash { get; init; }
         
         public UInt32? Index { get; init; }
@@ -27,35 +27,25 @@ namespace Casper.Network.SDK.Types
             if (key.StartsWith(TOPIC_PREFIX))
             {
                 key = key.Substring(TOPIC_PREFIX.Length);
-                key = key.Replace("entity-contract-", "");
-                key = key.Replace("entity-system-", "");
-                key = key.Replace("entity-account-", "");
                 var parts = key.Split('-');
-                if(parts.Length == 2)
-                {
-                    HashAddr = parts[0];
-                    TopicHash = parts[1];
-                }
-                else
-                    throw new Exception("Key not valid. It should have a hash address and a topic hash.");
+                if (parts.Length != 4)
+                    throw new Exception("Key not valid. It should have an entity address and a topic hash.");
+
+                AddressableEntity = new AddressableEntityKey($"{parts[0]}-{parts[1]}-{parts[2]}");
+                TopicHash = parts[3];
             }
             else
             {
-                key = key.Replace("entity-contract-", "");
-                key = key.Replace("entity-system-", "");
-                key = key.Replace("entity-account-", "");
                 var parts = key.Split('-');
-                if (parts.Length == 3)
-                {
-                    HashAddr = parts[0];
-                    TopicHash = parts[1];
-                    
-                    if(parts[2].Length == 0)
-                        throw new Exception("Key not valid. Expected a non-empty message index.");
-                    Index = Convert.ToUInt32(parts[2], 16);
-                }
-                else
-                    throw new Exception("Key not valid. It should have a hash address, a topic hash, and a message index.");
+                if (parts.Length != 5)
+                    throw new Exception("Key not valid. It should have an entity address, a topic hash, and a message index.");
+
+                AddressableEntity = new AddressableEntityKey($"{parts[0]}-{parts[1]}-{parts[2]}");
+                TopicHash = parts[3];
+                
+                if(parts[4].Length == 0)
+                    throw new Exception("Key not valid. Expected a non-empty message index.");
+                Index = Convert.ToUInt32(parts[4], 16);
             }
         }
     
@@ -66,8 +56,7 @@ namespace Casper.Network.SDK.Types
             var ms = new MemoryStream(key);
             var reader = new BinaryReader(ms);
             
-            var hash = reader.ReadBytes(32);
-            HashAddr = Hex.ToHexString(hash);
+            AddressableEntity = new AddressableEntityKey(reader);
             
             var topic = reader.ReadBytes(32);
             TopicHash = Hex.ToHexString(topic);
@@ -78,7 +67,7 @@ namespace Casper.Network.SDK.Types
 
             Key = KEY_PREFIX +
                   (Index.HasValue ? "" : TOPIC_PREFIX) +
-                  HashAddr + "-" +
+                  AddressableEntity.ToString() + "-" +
                   TopicHash +
                   (Index.HasValue ? "-" + Index.Value.ToString("x") : "");
         }

--- a/Casper.Network.SDK/Types/Package.cs
+++ b/Casper.Network.SDK/Types/Package.cs
@@ -47,8 +47,9 @@ namespace Casper.Network.SDK.Types
         /// <summary>
         /// The hex-encoded address of the addressable entity.
         /// </summary>
-        [JsonPropertyName("addressable_entity_hash")]
-        public string AddressableEntityHash { get; init; }
+        [JsonPropertyName("entity_addr")]
+        [JsonConverter(typeof(AddressableEntityKey.AddressableEntityKeyConverter))]
+        public AddressableEntityKey AddressableEntity { get; init; }
     }
 
     public class NamedUserGroup
@@ -107,7 +108,7 @@ namespace Casper.Network.SDK.Types
                     {
                         EntityVersion = new EntityVersion()
                             { Version = v.Version, ProtocolVersionMajor = v.ProtocolVersionMajor },
-                        AddressableEntityHash = v.Hash,
+                        AddressableEntity = new AddressableEntityKey("entity-contract-" + v.Hash.Replace("contract-", "")),
                     }).ToList(),
                 Groups = contractPackage.Groups.Select(g => new NamedUserGroup()
                     {


### PR DESCRIPTION
### Summary

message topic global state keys contain the addressable entity prefix `entity-contract-`. This PR handles this prefix.

### TODO

- [ ] ...

### Checklist

- [X] Code is properly formatted
- [X] All commits are signed
- [X] Tests included/updated or not needed
- [X] Documentation (manuals or wiki) has been updated or is not required


