### PR TITLE
Add SSE section for Casper .NET SDK 3.x Introduced a new section on W…

### DIFF
--- a/Docs/Articles/WorkingWithSSE.md
+++ b/Docs/Articles/WorkingWithSSE.md
@@ -1,0 +1,13 @@
+# Working with Server-Sent Events (SSE) in Casper .NET SDK 3.x
+
+The new Casper Node **2.x** version introduced changes to the SSE protocol. To support these changes, the Casper .NET SDK has been updated to version **3.x**, introducing a new optional parameter `nodeVersion` in the `ServerEventsClient`.
+
+## Creating `ServerEventsClient` for Node v2.x (Default)
+
+When working with the new Casper Node version **2.x**, instantiate the `ServerEventsClient` without specifying the `nodeVersion`. The default value is set to `2`:
+
+```csharp
+var sse = new ServerEventsClient(eventIpAddress, localNetPort, nodeVersion: 1); // For versions 1.x
+
+var sse = new ServerEventsClient(eventIpAddress, localNetPort); // The default value is 2
+```


### PR DESCRIPTION
Working with Server-Sent Events (SSE) in the documentation for the Casper .NET SDK 3.x. This includes details about the new optional nodeVersion parameter in the ServerEventsClient class and provides example code for creating a ServerEventsClient for Node version 2.x, demonstrating the default behavior when odeVersion is not specified.


* Resolves: # <!-- related github issue -->

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits are signed
- [ ] Tests included/updated or not needed
- [ ] Documentation (manuals or wiki) has been updated or is not required


