### PR TITLE
[CSDK-258] Added protocol_version_major optional field to ByPackageHash and ByPackageName contract calls

### DIFF
--- a/Casper.Network.SDK.Test/TransactionBuilder/ProtocolVersionMajor.cs
+++ b/Casper.Network.SDK.Test/TransactionBuilder/ProtocolVersionMajor.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using Casper.Network.SDK.Types;
+using NUnit.Framework;
+
+namespace NetCasperTest.TransactionBuilder
+{
+    public class ProtocolVersionMajor
+    {
+        [Test]
+        public void ByPackageHashNoVersionTest()
+        {
+            var testKey = KeyPair.CreateNew(KeyAlgo.SECP256K1);
+            var runtimeArgs = new List<NamedArg>();
+            
+            var transaction = new Transaction.ContractCallBuilder()
+                .From(testKey.PublicKey)
+                .Payment(2_500_000_000, 2)
+                .ChainName("chain_name")
+                .ByPackageHash("0101010101010101010101010101010101010101010101010101010101010101")
+                .EntryPoint("counter_inc")
+                .RuntimeArgs(runtimeArgs)
+                .Build();
+            
+            var txv1 = (TransactionV1)transaction;
+            var target = txv1.Payload.Target as StoredTransactionV1Target;
+            var invocationTarget = target.Id as ByPackageHashInvocationTarget;
+            Assert.AreEqual("0101010101010101010101010101010101010101010101010101010101010101", invocationTarget.Hash);
+            Assert.AreEqual(null, invocationTarget.Version);
+            Assert.AreEqual(null, invocationTarget.ProtocolVersionMajor);
+        }
+        
+        [Test]
+        public void ByPackageHashWithVersionTest()
+        {
+            var testKey = KeyPair.CreateNew(KeyAlgo.SECP256K1);
+            var runtimeArgs = new List<NamedArg>();
+            
+            var transaction = new Transaction.ContractCallBuilder()
+                .From(testKey.PublicKey)
+                .Payment(2_500_000_000, 2)
+                .ChainName("chain_name")
+                .ByPackageHash("0101010101010101010101010101010101010101010101010101010101010101", null, 2)
+                // .ByPackageName("counter_package_name", 1, 1)
+                .EntryPoint("counter_inc")
+                .RuntimeArgs(runtimeArgs)
+                .Build();
+            
+            var txv1 = (TransactionV1)transaction;
+            var target = txv1.Payload.Target as StoredTransactionV1Target;
+            var invocationTarget = target.Id as ByPackageHashInvocationTarget;
+            Assert.AreEqual("0101010101010101010101010101010101010101010101010101010101010101", invocationTarget.Hash);
+            Assert.AreEqual(null, invocationTarget.Version);
+            Assert.AreEqual(2, invocationTarget.ProtocolVersionMajor);
+        }
+        
+        [Test]
+        public void ByPackageNameNoVersionTest()
+        {
+            var testKey = KeyPair.CreateNew(KeyAlgo.SECP256K1);
+            var runtimeArgs = new List<NamedArg>();
+            
+            var transaction = new Transaction.ContractCallBuilder()
+                .From(testKey.PublicKey)
+                .Payment(2_500_000_000, 2)
+                .ChainName("chain_name")
+                .ByPackageName("counter_package_name")
+                .EntryPoint("counter_inc")
+                .RuntimeArgs(runtimeArgs)
+                .Build();
+            
+            var txv1 = (TransactionV1)transaction;
+            var target = txv1.Payload.Target as StoredTransactionV1Target;
+            var invocationTarget = target.Id as ByPackageNameInvocationTarget;
+            Assert.AreEqual("counter_package_name", invocationTarget.Name);
+            Assert.AreEqual(null, invocationTarget.Version);
+            Assert.AreEqual(null, invocationTarget.ProtocolVersionMajor);
+        }
+        
+        [Test]
+        public void ByPackageNameWithVersionTest()
+        {
+            var testKey = KeyPair.CreateNew(KeyAlgo.SECP256K1);
+            var runtimeArgs = new List<NamedArg>();
+            
+            var transaction = new Transaction.ContractCallBuilder()
+                .From(testKey.PublicKey)
+                .Payment(2_500_000_000, 2)
+                .ChainName("chain_name")
+                .ByPackageName("counter_package_name", 1, 2)
+                .EntryPoint("counter_inc")
+                .RuntimeArgs(runtimeArgs)
+                .Build();
+            
+            var txv1 = (TransactionV1)transaction;
+            var target = txv1.Payload.Target as StoredTransactionV1Target;
+            var invocationTarget = target.Id as ByPackageNameInvocationTarget;
+            Assert.AreEqual("counter_package_name", invocationTarget.Name);
+            Assert.AreEqual(1, invocationTarget.Version);
+            Assert.AreEqual(2, invocationTarget.ProtocolVersionMajor);
+        }
+        
+        [Test]
+        public void ByPackageNameNoVersionJsonTest()
+        {
+            var testKey = KeyPair.CreateNew(KeyAlgo.SECP256K1);
+            var runtimeArgs = new List<NamedArg>();
+            
+            var transaction = new Transaction.ContractCallBuilder()
+                .From(testKey.PublicKey)
+                .Payment(2_500_000_000, 2)
+                .ChainName("chain_name")
+                .ByPackageName("counter_package_name")
+                .EntryPoint("counter_inc")
+                .RuntimeArgs(runtimeArgs)
+                .Build();
+            
+            var json = JsonSerializer.Serialize(transaction);
+            Assert.IsNotNull(json);
+            Assert.IsFalse(json.Contains("protocol_version_major"));
+        }
+        
+        [Test]
+        public void ByPackageNameWithVersionJsonTest()
+        {
+            var testKey = KeyPair.CreateNew(KeyAlgo.SECP256K1);
+            var runtimeArgs = new List<NamedArg>();
+            
+            var transaction = new Transaction.ContractCallBuilder()
+                .From(testKey.PublicKey)
+                .Payment(2_500_000_000, 2)
+                .ChainName("chain_name")
+                .ByPackageName("counter_package_name", 1, 2)
+                .EntryPoint("counter_inc")
+                .RuntimeArgs(runtimeArgs)
+                .Build();
+            
+            var json = JsonSerializer.Serialize(transaction);
+            Assert.IsNotNull(json);
+            Assert.IsTrue(json.Contains("\"protocol_version_major\":2"));
+        }
+    }
+}

--- a/Casper.Network.SDK/Types/TransactionBuilder.cs
+++ b/Casper.Network.SDK/Types/TransactionBuilder.cs
@@ -581,15 +581,15 @@ namespace Casper.Network.SDK.Types
                 return this;
             }
 
-            public ContractCallBuilder ByPackageHash(string contractHash, UInt32? version = null, UInt32? protocolVersionMajor = null)
+            public ContractCallBuilder ByPackageHash(string contractPackageHash, UInt32? version = null, UInt32? protocolVersionMajor = null)
             {
-                _invocationTarget = TransactionV1Target.StoredByPackageHash(contractHash, version, protocolVersionMajor);
+                _invocationTarget = TransactionV1Target.StoredByPackageHash(contractPackageHash, version, protocolVersionMajor);
                 return this;
             }
 
-            public ContractCallBuilder ByPackageName(string name, UInt32? version = null)
+            public ContractCallBuilder ByPackageName(string packageName, UInt32? version = null, UInt32? protocolVersionMajor = null)
             {
-                _invocationTarget = TransactionV1Target.StoredByPackageName(name, version);
+                _invocationTarget = TransactionV1Target.StoredByPackageName(packageName, version, protocolVersionMajor);
                 return this;
             }
 

--- a/Casper.Network.SDK/Types/TransactionV1Target.cs
+++ b/Casper.Network.SDK/Types/TransactionV1Target.cs
@@ -88,20 +88,31 @@ namespace Casper.Network.SDK.Types
         [JsonPropertyName("name")] public string Name { get; init; }
 
         [JsonPropertyName("version")] public UInt32? Version { get; init; }
+        
+        [JsonPropertyName("protocol_version_major")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public UInt32? ProtocolVersionMajor { get; init; }
 
         const ushort TAG_FIELD_INDEX = 0;
         const byte BY_PACKAGE_NAME_VARIANT = 3;
         const ushort BY_PACKAGE_NAME_NAME_INDEX = 1;
         const ushort BY_PACKAGE_NAME_VERSION_INDEX = 2;
+        const ushort BY_PACKAGE_HASH_PROTOCOL_VERSION_MAJOR_INDEX = 3;
 
         public byte[] ToBytes()
         {
-            return new CalltableSerialization()
+            var calltable =  new CalltableSerialization()
                 .AddField(TAG_FIELD_INDEX, new byte[] { BY_PACKAGE_NAME_VARIANT })
                 .AddField(BY_PACKAGE_NAME_NAME_INDEX, CLValue.String(Name))
                 .AddField(BY_PACKAGE_NAME_VERSION_INDEX, Version.HasValue
                     ? CLValue.Option(CLValue.U32(Version.Value))
-                    : CLValue.OptionNone(CLType.U32)).GetBytes();
+                    : CLValue.OptionNone(CLType.U32));
+            
+            if (ProtocolVersionMajor.HasValue)
+                calltable.AddField(BY_PACKAGE_HASH_PROTOCOL_VERSION_MAJOR_INDEX,
+                    CLValue.U32(ProtocolVersionMajor.Value));
+            
+            return calltable.GetBytes();
         }
     }
 
@@ -371,11 +382,11 @@ namespace Casper.Network.SDK.Types
             };
         }
 
-        public static StoredTransactionV1Target StoredByPackageName(string name, UInt32? version = null)
+        public static StoredTransactionV1Target StoredByPackageName(string name, UInt32? version = null, UInt32? protocolVersionMajor = null)
         {
             return new StoredTransactionV1Target()
             {
-                Id = new ByPackageNameInvocationTarget() { Name = name, Version = version },
+                Id = new ByPackageNameInvocationTarget() { Name = name, Version = version, ProtocolVersionMajor = protocolVersionMajor },
             };
         }
 


### PR DESCRIPTION
### Summary
Added protocol_version_major optional field to ByPackageHash and ByPackageName contract calls. This field was introduced in v2.0.3 of the casper-node software.

### TODO

### Checklist

- [X] Code is properly formatted
- [X] All commits are signed
- [X] Tests included/updated or not needed
- [X] Documentation (manuals or wiki) has been updated or is not required


