### PR TITLE
Fix DocFX GitHub Action workflow

### DIFF
--- a/.github/workflows/docfx-publish.yml
+++ b/.github/workflows/docfx-publish.yml
@@ -13,13 +13,22 @@ jobs:
     runs-on: ubuntu-latest
     name: Generate and publish the docs
     steps:
-    - uses: actions/checkout@v1
-      name: Checkout code
-    - uses: davidatwhiletrue/docfx-action@v1.0.0
-      name: Build and Publish Documentation
-      with:
-        args: Docs/docfx.json
-      env:
-        BUILD_DIR: Docs/_site # docfx's default output directory is _site
-        GH_PAT: ${{ secrets.GH_PAT }} # See https://github.com/maxheld83/ghpages
+    - name: Checkout code
+      uses: actions/checkout@v6
 
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Install DocFX
+      run: dotnet tool install -g docfx
+
+    - name: Build Documentation
+      run: docfx Docs/docfx.json
+
+    - name: Publish to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: Docs/_site


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

### Summary

The `davidatwhiletrue/docfx-action@v1.0.0` uses a `mono:latest` base image based on Debian Buster, which reached End-of-Life in June 2024. `apt update` fails because Buster repositories have been archived, causing the workflow to fail with:

```
E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
```

This PR replaces the broken Docker-based action with a modern, native approach:
- `actions/checkout@v6` (was `@v1`)
- `actions/setup-dotnet@v5` (new, for .NET 8)
- `docfx` installed as a .NET global tool
- `peaceiris/actions-gh-pages@v4` for publishing to GitHub Pages

Also updates action versions to Node.js 24 compatible ones to resolve deprecation warnings.

### TODO

- [x] Replace broken docfx-action with native .NET tool approach
- [x] Update action versions to Node.js 24 compatible

### Checklist

- [x] Code is properly formatted
- [x] All commits are signed
- [ ] Tests included/updated or not needed
- [ ] Documentation (manuals or wiki) has been updated or is not required