### PR TITLE
Refactor KeyPair raw byte handling

### DIFF
--- a/Casper.Network.SDK.Test/BinaryReaderExtenstionsTest.cs
+++ b/Casper.Network.SDK.Test/BinaryReaderExtenstionsTest.cs
@@ -139,7 +139,7 @@ namespace NetCasperTest
         [Test]
         public void ReadPublicKeyTest()
         {
-            var key = KeyPair.CreateNew(KeyAlgo.ED25519);
+            var key = KeyPair.Create(KeyAlgo.ED25519);
             var bytes = key.PublicKey.GetBytes();
 
             var reader = new BinaryReader(new MemoryStream(bytes));
@@ -153,7 +153,7 @@ namespace NetCasperTest
         {
             // test with an AccountHash key
             //
-            var key = KeyPair.CreateNew(KeyAlgo.ED25519);
+            var key = KeyPair.Create(KeyAlgo.ED25519);
             var accHash = key.PublicKey.GetAccountHash();
             var gsKey = GlobalStateKey.FromString(accHash);
 

--- a/Casper.Network.SDK.Test/CLValueReaderTest.cs
+++ b/Casper.Network.SDK.Test/CLValueReaderTest.cs
@@ -215,7 +215,7 @@ namespace NetCasperTest
         [Test]
         public void ReadPublicKeyEd25519Test()
         {
-            var publicKey = KeyPair.CreateNew(KeyAlgo.ED25519).PublicKey;
+            var publicKey = KeyPair.Create(KeyAlgo.ED25519).PublicKey;
             var original = CLValue.PublicKey(publicKey);
             var result = ReaderFor(original.Bytes).Read(CLType.PublicKey);
 
@@ -228,7 +228,7 @@ namespace NetCasperTest
         [Test]
         public void ReadPublicKeySecp256k1Test()
         {
-            var publicKey = KeyPair.CreateNew(KeyAlgo.SECP256K1).PublicKey;
+            var publicKey = KeyPair.Create(KeyAlgo.SECP256K1).PublicKey;
             var original = CLValue.PublicKey(publicKey);
             var result = ReaderFor(original.Bytes).Read(CLType.PublicKey);
 

--- a/Casper.Network.SDK.Test/KeysTest.cs
+++ b/Casper.Network.SDK.Test/KeysTest.cs
@@ -199,7 +199,7 @@ namespace NetCasperTest
         [Test]
         public void WritePrivateKeyToPemEd25519()
         {
-            var keyPair = KeyPair.CreateNew(KeyAlgo.ED25519);
+            var keyPair = KeyPair.Create(KeyAlgo.ED25519);
             Assert.IsNotNull(keyPair);
             Assert.IsNotNull(keyPair.PublicKey);
 
@@ -221,7 +221,7 @@ namespace NetCasperTest
         [Test]
         public void WritePrivateKeyToPemSecp256K1()
         {
-            var keyPair = KeyPair.CreateNew(KeyAlgo.SECP256K1);
+            var keyPair = KeyPair.Create(KeyAlgo.SECP256K1);
             Assert.IsNotNull(keyPair);
             Assert.IsNotNull(keyPair.PublicKey);
 
@@ -244,12 +244,156 @@ namespace NetCasperTest
         public void WritePrivateKeyToPemFailsForExistingFile()
         {
             var tmpfile = Path.GetTempFileName();
-            var keyPair = KeyPair.CreateNew(KeyAlgo.SECP256K1);
+            var keyPair = KeyPair.Create(KeyAlgo.SECP256K1);
             Assert.IsNotNull(keyPair);
-            
+
             var ex =Assert.Catch<Exception>(() => keyPair.WriteToPem(tmpfile));
             Assert.IsNotNull(ex);
             Assert.IsTrue(ex.Message.StartsWith("Target file already exists."));
+        }
+
+        [Test]
+        public void TestKeyPairWritePublicKeyToPemEd25519()
+        {
+            var keyPair = KeyPair.Create(KeyAlgo.ED25519);
+
+            var tmpfile = Path.GetTempFileName();
+            File.Delete(tmpfile);
+
+            keyPair.WritePublicKeyToPem(tmpfile);
+
+            var pk = PublicKey.FromPem(tmpfile);
+            Assert.AreEqual(keyPair.PublicKey, pk);
+            Assert.AreEqual(keyPair.PublicKey.ToAccountHex(), pk.ToAccountHex());
+        }
+
+        [Test]
+        public void TestKeyPairWritePublicKeyToPemSecp256K1()
+        {
+            var keyPair = KeyPair.Create(KeyAlgo.SECP256K1);
+
+            var tmpfile = Path.GetTempFileName();
+            File.Delete(tmpfile);
+
+            keyPair.WritePublicKeyToPem(tmpfile);
+
+            var pk = PublicKey.FromPem(tmpfile);
+            Assert.AreEqual(keyPair.PublicKey, pk);
+            Assert.AreEqual(keyPair.PublicKey.ToAccountHex(), pk.ToAccountHex());
+        }
+
+        [Test]
+        public void WritePublicKeyToPemFailsForExistingFileOnKeyPair()
+        {
+            var tmpfile = Path.GetTempFileName();
+            var keyPair = KeyPair.Create(KeyAlgo.SECP256K1);
+
+            var ex = Assert.Catch<Exception>(() => keyPair.WritePublicKeyToPem(tmpfile));
+            Assert.IsNotNull(ex);
+            Assert.IsTrue(ex.Message.StartsWith("Target file already exists."));
+        }
+
+        [Test]
+        public void TestKeyPairFromBytesEd25519()
+        {
+            var original = KeyPair.Create(KeyAlgo.ED25519);
+            var roundTrip = KeyPair.FromBytes(original.RawBytes, KeyAlgo.ED25519);
+
+            Assert.AreEqual(original.PublicKey, roundTrip.PublicKey);
+            Assert.IsTrue(original.RawBytes.SequenceEqual(roundTrip.RawBytes));
+
+            byte[] message = Hex.Decode("000102030405060708090A0B0C0D0E0F10111213");
+            var sig = roundTrip.Sign(message);
+            Assert.IsTrue(original.PublicKey.VerifySignature(message, sig));
+        }
+
+        [Test]
+        public void TestKeyPairFromBytesEd25519RejectsWrongLength()
+        {
+            var tooShort = Hex.Decode("01");
+            var tooLong = Hex.Decode("000000000000000000000000000000000000000000000000000000000000000001");
+
+            Assert.Catch<ArgumentException>(() => KeyPair.FromBytes(tooShort, KeyAlgo.ED25519));
+            Assert.Catch<ArgumentException>(() => KeyPair.FromBytes(tooLong, KeyAlgo.ED25519));
+        }
+
+        [Test]
+        public void TestKeyPairFromBytesSecp256K1()
+        {
+            var original = KeyPair.Create(KeyAlgo.SECP256K1);
+            var roundTrip = KeyPair.FromBytes(original.RawBytes, KeyAlgo.SECP256K1);
+
+            Assert.AreEqual(original.PublicKey, roundTrip.PublicKey);
+            Assert.IsTrue(original.RawBytes.SequenceEqual(roundTrip.RawBytes));
+
+            byte[] message = Hex.Decode("000102030405060708090A0B0C0D0E0F10111213");
+            var sig = roundTrip.Sign(message);
+            Assert.IsTrue(original.PublicKey.VerifySignature(message, sig));
+        }
+
+        [Test]
+        public void TestKeyPairFromBytesSecp256K1PreservesThirtyTwoByteScalar()
+        {
+            var privateKey = Hex.Decode("0000000000000000000000000000000000000000000000000000000000000001");
+            var keyPair = KeyPair.FromBytes(privateKey, KeyAlgo.SECP256K1);
+
+            Assert.AreEqual(32, keyPair.RawBytes.Length);
+            Assert.IsTrue(privateKey.SequenceEqual(keyPair.RawBytes));
+        }
+
+        [Test]
+        public void TestKeyPairFromBytesSecp256K1RejectsWrongLength()
+        {
+            var tooShort = Hex.Decode("01");
+            var tooLong = Hex.Decode("000000000000000000000000000000000000000000000000000000000000000001");
+
+            Assert.Catch<ArgumentException>(() => KeyPair.FromBytes(tooShort, KeyAlgo.SECP256K1));
+            Assert.Catch<ArgumentException>(() => KeyPair.FromBytes(tooLong, KeyAlgo.SECP256K1));
+        }
+
+        [Test]
+        public void TestKeyPairSignSecp256K1ProducesLowS()
+        {
+            var keyPair = KeyPair.Create(KeyAlgo.SECP256K1);
+            byte[] message = Hex.Decode("000102030405060708090A0B0C0D0E0F10111213");
+
+            for (int i = 0; i < 20; i++)
+            {
+                var sig = keyPair.Sign(message);
+                Assert.AreEqual(64, sig.Length, "ECDSA signature must be 64 bytes (r||s).");
+                Assert.AreEqual(0, sig[32] & 0x80, "s has the high bit set; low-S rule violated.");
+                Assert.IsTrue(keyPair.PublicKey.VerifySignature(message, sig));
+            }
+        }
+
+        [Test]
+        public void TestKeyPairSignFailsForTamperedMessage()
+        {
+            var keyPair = KeyPair.Create(KeyAlgo.ED25519);
+            var message = Hex.Decode("000102030405060708090A0B0C0D0E0F10111213");
+            var signature = keyPair.Sign(message);
+
+            Assert.IsTrue(keyPair.PublicKey.VerifySignature(message, signature));
+
+            var tamperedMessage = (byte[]) message.Clone();
+            tamperedMessage[0] ^= 0x01;
+            Assert.IsFalse(keyPair.PublicKey.VerifySignature(tamperedMessage, signature));
+
+            var tamperedSig = (byte[]) signature.Clone();
+            tamperedSig[0] ^= 0x01;
+            Assert.IsFalse(keyPair.PublicKey.VerifySignature(message, tamperedSig));
+
+            var other = KeyPair.Create(KeyAlgo.ED25519);
+            Assert.IsFalse(other.PublicKey.VerifySignature(message, signature));
+        }
+
+        [Test]
+        public void TestKeyPairFromPemMissingFile()
+        {
+            var missing = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".pem");
+            var ex = Assert.Catch<FileNotFoundException>(() => KeyPair.FromPem(missing));
+            Assert.IsNotNull(ex);
+            Assert.AreEqual(missing, ex.FileName);
         }
     }
 }

--- a/Casper.Network.SDK.Test/NctlGetXTest.cs
+++ b/Casper.Network.SDK.Test/NctlGetXTest.cs
@@ -109,7 +109,7 @@ namespace NetCasperTest
 
             try
             {
-                var key1 = KeyPair.CreateNew(KeyAlgo.ED25519);
+                var key1 = KeyPair.Create(KeyAlgo.ED25519);
 
                 await _client.GetAccountInfo(key1.PublicKey);
                 Assert.Fail("Exception expected");
@@ -122,7 +122,7 @@ namespace NetCasperTest
             
             try
             {
-                var key1 = KeyPair.CreateNew(KeyAlgo.ED25519);
+                var key1 = KeyPair.Create(KeyAlgo.ED25519);
 
                 await _client.QueryBalance(key1.PublicKey);
                 Assert.Fail("Exception expected");

--- a/Casper.Network.SDK.Test/NctlTransferTest.cs
+++ b/Casper.Network.SDK.Test/NctlTransferTest.cs
@@ -24,7 +24,7 @@ namespace NetCasperTest
         [Test, Order(1)]
         public async Task TransferFromFaucetTest()
         {
-            _myAccount = KeyPair.CreateNew(KeyAlgo.SECP256K1);
+            _myAccount = KeyPair.Create(KeyAlgo.SECP256K1);
             
             var deploy = DeployTemplates.StandardTransfer(
                 _faucetKey.PublicKey,
@@ -80,9 +80,7 @@ namespace NetCasperTest
         [Test, Order(4)]
         public async Task CatchFailedTransferTest()
         {
-            Assert.IsNotNull(_transferKey, "This test must run after TransferFromFaucetTest");
-
-            var otherAccount = KeyPair.CreateNew(KeyAlgo.SECP256K1);
+            var otherAccount = KeyPair.Create(KeyAlgo.SECP256K1);
             
             var deploy = DeployTemplates.StandardTransfer(
                 _myAccount.PublicKey,
@@ -106,7 +104,7 @@ namespace NetCasperTest
         [Test, Order(6)]
         public async Task CatchUnknownAcctTransferTest()
         {
-            var newAccount = KeyPair.CreateNew(KeyAlgo.SECP256K1);
+            var newAccount = KeyPair.Create(KeyAlgo.SECP256K1);
             
             var deploy = DeployTemplates.StandardTransfer(
                 newAccount.PublicKey,

--- a/Casper.Network.SDK.Test/ServerEventsClientTest.cs
+++ b/Casper.Network.SDK.Test/ServerEventsClientTest.cs
@@ -92,7 +92,7 @@ namespace NetCasperTest
 
         private async Task MakeTransfer()
         {
-            KeyPair myAccount = KeyPair.CreateNew(KeyAlgo.SECP256K1);
+            KeyPair myAccount = KeyPair.Create(KeyAlgo.SECP256K1);
             
             var deploy = DeployTemplates.StandardTransfer(
                 _faucetKey.PublicKey,

--- a/Casper.Network.SDK.Test/TransactionBuilder/ProtocolVersionMajor.cs
+++ b/Casper.Network.SDK.Test/TransactionBuilder/ProtocolVersionMajor.cs
@@ -10,7 +10,7 @@ namespace NetCasperTest.TransactionBuilder
         [Test]
         public void ByPackageHashNoVersionTest()
         {
-            var testKey = KeyPair.CreateNew(KeyAlgo.SECP256K1);
+            var testKey = KeyPair.Create(KeyAlgo.SECP256K1);
             var runtimeArgs = new List<NamedArg>();
             
             var transaction = new Transaction.ContractCallBuilder()
@@ -33,7 +33,7 @@ namespace NetCasperTest.TransactionBuilder
         [Test]
         public void ByPackageHashWithVersionTest()
         {
-            var testKey = KeyPair.CreateNew(KeyAlgo.SECP256K1);
+            var testKey = KeyPair.Create(KeyAlgo.SECP256K1);
             var runtimeArgs = new List<NamedArg>();
             
             var transaction = new Transaction.ContractCallBuilder()
@@ -57,7 +57,7 @@ namespace NetCasperTest.TransactionBuilder
         [Test]
         public void ByPackageNameNoVersionTest()
         {
-            var testKey = KeyPair.CreateNew(KeyAlgo.SECP256K1);
+            var testKey = KeyPair.Create(KeyAlgo.SECP256K1);
             var runtimeArgs = new List<NamedArg>();
             
             var transaction = new Transaction.ContractCallBuilder()
@@ -80,7 +80,7 @@ namespace NetCasperTest.TransactionBuilder
         [Test]
         public void ByPackageNameWithVersionTest()
         {
-            var testKey = KeyPair.CreateNew(KeyAlgo.SECP256K1);
+            var testKey = KeyPair.Create(KeyAlgo.SECP256K1);
             var runtimeArgs = new List<NamedArg>();
             
             var transaction = new Transaction.ContractCallBuilder()
@@ -103,7 +103,7 @@ namespace NetCasperTest.TransactionBuilder
         [Test]
         public void ByPackageNameNoVersionJsonTest()
         {
-            var testKey = KeyPair.CreateNew(KeyAlgo.SECP256K1);
+            var testKey = KeyPair.Create(KeyAlgo.SECP256K1);
             var runtimeArgs = new List<NamedArg>();
             
             var transaction = new Transaction.ContractCallBuilder()
@@ -123,7 +123,7 @@ namespace NetCasperTest.TransactionBuilder
         [Test]
         public void ByPackageNameWithVersionJsonTest()
         {
-            var testKey = KeyPair.CreateNew(KeyAlgo.SECP256K1);
+            var testKey = KeyPair.Create(KeyAlgo.SECP256K1);
             var runtimeArgs = new List<NamedArg>();
             
             var transaction = new Transaction.ContractCallBuilder()

--- a/Casper.Network.SDK/Types/KeyPair.cs
+++ b/Casper.Network.SDK/Types/KeyPair.cs
@@ -4,6 +4,7 @@ using Org.BouncyCastle.Asn1.X9;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Generators;
 using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Math;
 using Org.BouncyCastle.Math.EC.Rfc8032;
 using Org.BouncyCastle.Security;
 using Org.BouncyCastle.Utilities.Encoders;
@@ -18,9 +19,20 @@ namespace Casper.Network.SDK.Types
     /// </summary>
     public class KeyPair
     {
+        private const int PrivateKeyByteSize = 32;
+
+        /// <summary>
+        /// The public key derived from the private key.
+        /// </summary>
         public PublicKey PublicKey { get; private set; }
 
-        private AsymmetricKeyParameter _publicKey;
+        /// <summary>
+        /// The raw bytes of the private key.
+        /// For ED25519, the 32-byte seed.
+        /// For SECP256K1, the 32-byte big-endian unsigned scalar.
+        /// </summary>
+        public byte[] RawBytes => PrivateKeyRawBytes();
+
         private AsymmetricKeyParameter _privateKey;
 
         /// <summary>
@@ -28,52 +40,107 @@ namespace Casper.Network.SDK.Types
         /// </summary>
         public static KeyPair FromPem(string filePath)
         {
-            using (TextReader textReader = new StringReader(File.ReadAllText(filePath)))
-            {
-                var reader = new PemReader(textReader);
+            if (!File.Exists(filePath))
+                throw new FileNotFoundException($"PEM file not found: {filePath}", filePath);
 
-                var pemObject = reader.ReadObject();
-                if (pemObject is Ed25519PrivateKeyParameters privateKey)
+            using TextReader textReader = File.OpenText(filePath);
+            using var reader = new PemReader(textReader);
+            var pemObject = reader.ReadObject();
+            switch (pemObject)
+            {
+                case Ed25519PrivateKeyParameters privateKey:
                 {
                     var publicKey = privateKey.GeneratePublicKey();
 
                     return new KeyPair()
                     {
                         PublicKey = PublicKey.FromRawBytes(publicKey.GetEncoded(), KeyAlgo.ED25519),
-                        _publicKey = publicKey,
                         _privateKey = privateKey
                     };
                 }
-
-                if (pemObject is AsymmetricCipherKeyPair keyPair)
+                case AsymmetricCipherKeyPair keyPair:
                 {
                     var privKey = (ECPrivateKeyParameters) keyPair.Private;
                     if (privKey.PublicKeyParamSet.Id != "1.3.132.0.10")
                         throw new Exception(
-                            $"Wrong curve type. OID expected 1.3.132.0.10. Found ${privKey.PublicKeyParamSet.Id}");
+                            $"Wrong curve type. OID expected 1.3.132.0.10. Found {privKey.PublicKeyParamSet.Id}");
 
                     var q = privKey.Parameters.G.Multiply(privKey.D);
                     var pub = new ECPublicKeyParameters(privKey.AlgorithmName, q, privKey.PublicKeyParamSet);
 
-                    byte[] compressed = pub.Q.GetEncoded(true);
+                    var compressed = pub.Q.GetEncoded(true);
 
                     return new KeyPair()
                     {
                         PublicKey = PublicKey.FromRawBytes(compressed, KeyAlgo.SECP256K1),
-                        _publicKey = keyPair.Public,
                         _privateKey = keyPair.Private
                     };
                 }
-
-                throw new ArgumentException("Unsupported key format or it's not a private key PEM object.",
-                    nameof(filePath));
+                default:
+                    throw new ArgumentException("Unsupported key format or it's not a private key PEM object.",
+                        nameof(filePath));
             }
         }
 
         /// <summary>
-        /// Creates a new key pair with the specified elliptic curve.
+        /// Loads a key pair from a raw byte array containing the private key.
+        /// For ED25519, the 32-byte seed is expected.
+        /// For SECP256K1, the 32-byte big-endian unsigned scalar is expected.
         /// </summary>
+        public static KeyPair FromBytes(byte[] bytes, KeyAlgo keyAlgorithm)
+        {
+            if (bytes.Length != PrivateKeyByteSize)
+                throw new ArgumentException(
+                    $"Wrong private key format. Expected length is {PrivateKeyByteSize}",
+                    nameof(bytes));
+
+            switch (keyAlgorithm)
+            {
+                case KeyAlgo.ED25519:
+                {
+                    var privKey = new Ed25519PrivateKeyParameters(bytes, 0);
+                    var publicKey = privKey.GeneratePublicKey();
+
+                    return new KeyPair()
+                    {
+                        PublicKey = PublicKey.FromRawBytes(publicKey.GetEncoded(), KeyAlgo.ED25519),
+                        _privateKey = privKey
+                    };
+                }
+                case KeyAlgo.SECP256K1:
+                {
+                    var curve = ECNamedCurveTable.GetByName("secp256k1");
+                    var domainParams = new ECDomainParameters(curve.Curve, curve.G, curve.N, curve.H, curve.GetSeed());
+
+                    var d = new BigInteger(1, bytes);
+                    var privKey = new ECPrivateKeyParameters("ECDSA", d, domainParams);
+                    var q = privKey.Parameters.G.Multiply(privKey.D);
+
+                    var pub = new ECPublicKeyParameters(q, domainParams);
+                    var compressed = pub.Q.GetEncoded(true);
+
+                    return new KeyPair()
+                    {
+                        PublicKey = PublicKey.FromRawBytes(compressed, KeyAlgo.SECP256K1),
+                        _privateKey = privKey
+                    };
+                }
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(keyAlgorithm), keyAlgorithm,
+                        $"Unsupported key algorithm: {keyAlgorithm}");
+            }
+        }
+
+        [Obsolete("Use Create() instead.", false)]
         public static KeyPair CreateNew(KeyAlgo keyAlgorithm)
+        {
+            return Create(keyAlgorithm);
+        }
+
+        /// <summary>
+        /// Creates a new key pair with the specified algorithm.
+        /// </summary>
+        public static KeyPair Create(KeyAlgo keyAlgorithm)
         {
             if (keyAlgorithm == KeyAlgo.ED25519)
             {
@@ -85,7 +152,6 @@ namespace Casper.Network.SDK.Types
                 return new KeyPair()
                 {
                     PublicKey = PublicKey.FromRawBytes(publicKey.GetEncoded(), KeyAlgo.ED25519),
-                    _publicKey = publicKey,
                     _privateKey = newKey.Private
                 };
             }
@@ -102,12 +168,11 @@ namespace Casper.Network.SDK.Types
                 var newKey = generator.GenerateKeyPair();
 
                 var pk = newKey.Public as ECPublicKeyParameters;
-                byte[] compressed = pk.Q.GetEncoded(true);
+                var compressed = pk.Q.GetEncoded(true);
 
                 return new KeyPair()
                 {
                     PublicKey = PublicKey.FromRawBytes(compressed, KeyAlgo.SECP256K1),
-                    _publicKey = newKey.Public,
                     _privateKey = newKey.Private
                 };
             }
@@ -124,25 +189,21 @@ namespace Casper.Network.SDK.Types
             
             if (PublicKey.KeyAlgorithm == KeyAlgo.ED25519)
             {
-                using (var textWriter = File.CreateText(filePath))
-                {
-                    var writer = new PemWriter(textWriter);
-                    writer.WriteObject(_privateKey);
-                }
+                using var textWriter = File.CreateText(filePath);
+                var writer = new PemWriter(textWriter);
+                writer.WriteObject(_privateKey);
             }
             else
             {
-                byte[] bytes =
+                var bytes =
                     Hex.Decode(
                         "302E02010104200000000000000000000000000000000000000000000000000000000000000000A00706052B8104000A");
                 var privKey = (ECPrivateKeyParameters) _privateKey;
                 var skbytes = privKey.D.ToByteArrayUnsigned();
                 Array.Copy(skbytes, 0, bytes, 7 + (32 - skbytes.Length), skbytes.Length);
-                using (var textWriter = File.CreateText(filePath))
-                {
-                    var writer = new PemWriter(textWriter);
-                    writer.WriteObject(new PemObject("EC PRIVATE KEY", bytes));
-                }
+                using var textWriter = File.CreateText(filePath);
+                var writer = new PemWriter(textWriter);
+                writer.WriteObject(new PemObject("EC PRIVATE KEY", bytes));
             }
         }
 
@@ -151,15 +212,7 @@ namespace Casper.Network.SDK.Types
         /// </summary>
         public void WritePublicKeyToPem(string filePath)
         {
-            if (File.Exists(filePath))
-                throw new Exception("Target file already exists. Will not overwrite." +
-                                    Environment.NewLine + "File: " + filePath);
-            
-            using (var textWriter = File.CreateText(filePath))
-            {
-                var writer = new PemWriter(textWriter);
-                writer.WriteObject(_publicKey);
-            }
+            PublicKey.WriteToPem(filePath);
         }
 
         /// <summary>
@@ -167,33 +220,59 @@ namespace Casper.Network.SDK.Types
         /// </summary>
         public byte[] Sign(byte[] message)
         {
-            if (PublicKey.KeyAlgorithm == KeyAlgo.ED25519)
+            switch (PublicKey.KeyAlgorithm)
             {
-                byte[] signature = new byte[Ed25519.SignatureSize];
-                var sk = (Ed25519PrivateKeyParameters) _privateKey;
-                Ed25519.Sign(sk.GetEncoded(), 0, message, 0, message.Length, signature, 0);
-
-                return signature;
-            }
-
-            if (PublicKey.KeyAlgorithm == KeyAlgo.SECP256K1)
-            {
-                SecureRandom k = new SecureRandom();
-                ParametersWithRandom param = new ParametersWithRandom(_privateKey, k);
-
-                var signer = SignerUtilities.GetSigner("SHA-256withPLAIN-ECDSA");
-                byte[] rs;
-                do
+                case KeyAlgo.ED25519:
                 {
+                    var signature = new byte[Ed25519.SignatureSize];
+                    var sk = (Ed25519PrivateKeyParameters) _privateKey;
+                    Ed25519.Sign(sk.GetEncoded(), 0, message, 0, message.Length, signature, 0);
+
+                    return signature;
+                }
+                case KeyAlgo.SECP256K1:
+                {
+                    var k = new SecureRandom();
+                    var param = new ParametersWithRandom(_privateKey, k);
+
+                    var signer = SignerUtilities.GetSigner("SHA-256withPLAIN-ECDSA");
                     signer.Init(forSigning: true, param);
                     signer.BlockUpdate(message, 0, message.Length);
-                    rs = signer.GenerateSignature();
-                } while ((rs[32] & 0x80) == 0x80); //discard s with first bit equal to 1
-                
-                return rs;
-            }
+                    var rs = signer.GenerateSignature();
 
-            throw new Exception("Unsupported key type.");
+                    if ((rs[32] & 0x80) == 0x80)
+                    {
+                        var curve = ECNamedCurveTable.GetByName("secp256k1");
+                        var n = curve.N;
+                        var sBytes = new byte[32];
+                        Array.Copy(rs, 32, sBytes, 0, 32);
+                        var lowS = n.Subtract(new BigInteger(1, sBytes)).ToByteArrayUnsigned();
+                        Array.Clear(rs, 32, 32);
+                        Array.Copy(lowS, 0, rs, 32 + (32 - lowS.Length), lowS.Length);
+                    }
+
+                    return rs;
+                }
+                default:
+                    throw new Exception("Unsupported key type.");
+            }
+        }
+
+        private byte[] PrivateKeyRawBytes()
+        {
+            if (PublicKey.KeyAlgorithm == KeyAlgo.ED25519)
+            {
+                var privKey = (Ed25519PrivateKeyParameters) _privateKey;
+                return privKey.GetEncoded();
+            }
+            else
+            {
+                var privKey = (ECPrivateKeyParameters) _privateKey;
+                var bytes = new byte[PrivateKeyByteSize];
+                var skbytes = privKey.D.ToByteArrayUnsigned();
+                Array.Copy(skbytes, 0, bytes, PrivateKeyByteSize - skbytes.Length, skbytes.Length);
+                return bytes;
+            }
         }
     }
 }

--- a/Docs/Articles/KeyManagement.md
+++ b/Docs/Articles/KeyManagement.md
@@ -4,14 +4,14 @@ Use the `PublicKey` and `KeyPair` classes to work with public keys and private k
 
 ### Creating new key pairs
 
-To create a new key pair use the method `CreateNew()` indicating the algorithm used:
+To create a new key pair use the method `Create()` indicating the algorithm used:
 
 ```csharp
-var newKeyPair = KeyPair.CreateNew(KeyAlgo.ED25519);
+var newKeyPair = KeyPair.Create(KeyAlgo.ED25519);
 ```
 
 ```csharp
-var anotherKeyPair = KeyPair.CreateNew(KeyAlgo.SECP256K1);
+var anotherKeyPair = KeyPair.Create(KeyAlgo.SECP256K1);
 ```
 
 ### Reading keys from PEM files


### PR DESCRIPTION
## Summary

Refactors `KeyPair` creation and serialization behavior around raw private-key bytes.

- Adds `KeyPair.Create(...)` while keeping `CreateNew(...)` as an obsolete compatibility wrapper.
- Adds `KeyPair.FromBytes(...)` and `RawBytes` for private-key byte round trips.
- Derives public keys from private key material instead of storing a separate public key parameter.
- Writes public-key PEMs through `PublicKey.WriteToPem(...)`.
- Normalizes secp256k1 signatures without producing intermittently invalid signatures.
- Enforces 32-byte private-key input for both ED25519 and SECP256K1.
- Updates internal tests/docs to use `KeyPair.Create(...)` instead of `CreateNew(...)`.

## Validation

- `dotnet test Casper.Network.SDK.Test/Casper.Network.SDK.Test.csproj --no-restore --filter "FullyQualifiedName~NetCasperTest.KeysTest"`
- `dotnet build Casper.Network.SDK.Test/Casper.Network.SDK.Test.csproj --no-restore`
- `dotnet build Casper.Network.SDK/Casper.Network.SDK.csproj --no-restore`
- `rg "KeyPair\\.CreateNew" -n`

Note: full `git diff --check` still reports an unrelated pre-existing trailing whitespace line in `Casper.Network.SDK.Test/NctlQueryGlobalStateTest.cs:27`, outside the keypair branch scope.