### PR TITLE
fix(BlockHeaderV2): fix incorrect parsing of BlockHeader Version2.

### DIFF
--- a/Casper.Network.SDK.Test/BlockTest.cs
+++ b/Casper.Network.SDK.Test/BlockTest.cs
@@ -1,0 +1,63 @@
+using System.IO;
+using System.Text.Json;
+using Casper.Network.SDK.Types;
+using NetCasperTest;
+using NUnit.Framework;
+
+namespace Casper.Network.SDK.Test
+{
+    public class BlockTest
+    {
+        [Test]
+        public void BlockHeaderV1Test()
+        {
+            string testFile = TestContext.CurrentContext.TestDirectory + "/TestData/block_header_v1.json";
+            var json = File.ReadAllText(testFile);
+
+            var _options = new JsonSerializerOptions()
+            {
+                WriteIndented = false,
+                Converters = { new BlockHeader.BlockHeaderConverter() }
+            };
+
+            var block = JsonSerializer.Deserialize<BlockHeader>(json, _options);
+
+            Assert.IsNotNull(block);
+            Assert.AreEqual("a11fbc52f7ace34fb3b84af0756462691af64f6e8ecf562171b8a61281dc1f00", block.StateRootHash);
+            Assert.AreEqual(1000, block.Height);
+            Assert.AreEqual(10, block.EraId);
+            
+            var blockV1 = (BlockHeaderV1)block;
+            Assert.IsNotNull(blockV1);
+            Assert.AreEqual(1000, blockV1.Height);
+            Assert.AreEqual(10, blockV1.EraId);
+            Assert.AreEqual("a11fbc52f7ace34fb3b84af0756462691af64f6e8ecf562171b8a61281dc1f00", blockV1.StateRootHash);
+        }
+        
+
+        [Test]
+        public void BlockHeaderV2Test()
+        {
+            string testFile = TestContext.CurrentContext.TestDirectory + "/TestData/block_header_v2.json";
+            var json = File.ReadAllText(testFile);
+            
+        var _options = new JsonSerializerOptions()
+        {
+            WriteIndented = false,
+            Converters = { new BlockHeader.BlockHeaderConverter() }
+        };
+        
+            var block = JsonSerializer.Deserialize<BlockHeader>(json,  _options);
+            
+            Assert.IsNotNull(block);
+            Assert.AreEqual("1bcde15749ac85e56f76d7428fc5c7e2a83b5e968dfe3845b0c46e929913c992", block.StateRootHash);
+            Assert.AreEqual(8803828, block.Height);
+            
+            var blockV2 = (BlockHeaderV2)block;
+            Assert.IsNotNull(blockV2);
+            Assert.AreEqual("1bcde15749ac85e56f76d7428fc5c7e2a83b5e968dfe3845b0c46e929913c992", blockV2.StateRootHash);
+            Assert.AreEqual("fd4cd1c938d4d8c4876940f2514af3251f127b20203fa8850ee57504579fe438", blockV2.LastSwitchBlockHash);
+            Assert.AreEqual(8803828, blockV2.Height);
+        }
+    }
+}

--- a/Casper.Network.SDK.Test/TestData/block_header_v1.json
+++ b/Casper.Network.SDK.Test/TestData/block_header_v1.json
@@ -1,0 +1,14 @@
+{
+  "Version1": {
+    "parent_hash": "61b6f6cb0afcb6ff20ad7dca007e90eccc31717943c5fe1451a620c16985721f",
+    "state_root_hash": "a11fbc52f7ace34fb3b84af0756462691af64f6e8ecf562171b8a61281dc1f00",
+    "body_hash": "34eb0b689accd4867e88c765e623da2f63265dbbb99f16e3f369b5ae92c29ebd",
+    "random_bit": false,
+    "accumulated_seed": "c2912f64fd5212ee49117862239814d4f3bb3a7d2dee67a22413d565b45e92b6",
+    "era_end": null,
+    "timestamp": "2021-04-09T14:53:50.976Z",
+    "era_id": 10,
+    "height": 1000,
+    "protocol_version": "1.0.0"
+  }
+}

--- a/Casper.Network.SDK.Test/TestData/block_header_v2.json
+++ b/Casper.Network.SDK.Test/TestData/block_header_v2.json
@@ -1,0 +1,17 @@
+{
+  "Version2": {
+    "parent_hash": "368341437a11a71ec589e62eec8e2fb82bc5539b02a76660f5bad03c124c5e36",
+    "state_root_hash": "1bcde15749ac85e56f76d7428fc5c7e2a83b5e968dfe3845b0c46e929913c992",
+    "body_hash": "d272bd190802c4872a303685f7e096878640b9ce7781a8ab1695dadd5d2a0b65",
+    "random_bit": false,
+    "accumulated_seed": "228b79f15324574618e8f5b4a864406f953b14f6e4bf6503525ee4b65a7f4aab",
+    "era_end": null,
+    "timestamp": "2026-08-11T12:55:16.837Z",
+    "era_id": 23277,
+    "height": 8803828,
+    "protocol_version": "2.2.2",
+    "proposer": "012d58e05b2057a84115709e0a6ccf000c6a83b4e8dfa389a680c1ab001864f1f2",
+    "current_gas_price": 1,
+    "last_switch_block_hash": "fd4cd1c938d4d8c4876940f2514af3251f127b20203fa8850ee57504579fe438"
+  }
+}

--- a/Casper.Network.SDK/Types/Block.cs
+++ b/Casper.Network.SDK/Types/Block.cs
@@ -202,7 +202,7 @@ namespace Casper.Network.SDK.Types
                         }
                         if (document.RootElement.TryGetProperty("Version2", out var headerV2))
                         {
-                            var blockHeaderV2 = JsonSerializer.Deserialize<BlockHeaderV2>(headerV1.GetRawText());
+                            var blockHeaderV2 = JsonSerializer.Deserialize<BlockHeaderV2>(headerV2.GetRawText());
                             return (BlockHeader)blockHeaderV2;
                         }
                         throw new JsonException("Cannot deserialize BlockHeader");


### PR DESCRIPTION
### Summary

Fix a bug where a BlockHeaderV2 JSON is not parsed correctly.
Found during counter tutorial updates.

### TODO

### Checklist

- [X] Code is properly formatted
- [X] All commits are signed
- [X] Tests included/updated or not needed
- [X] Documentation (manuals or wiki) has been updated or is not required


